### PR TITLE
fix(security): prevent ReDoS in extractTagContent

### DIFF
--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -158,16 +158,30 @@ function sanitizeText(text: string): string {
 }
 
 /**
+ * Escapes special regex characters in a string.
+ * @param str - The string to escape
+ * @returns The escaped string safe for use in RegExp
+ */
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Extracts content between XML-like tags.
  * @param text - The text to search in
- * @param tagName - The tag name to look for
+ * @param tagName - The tag name to look for (will be escaped for regex safety)
  * @returns The content between tags, or null if not found
  */
 export function extractTagContent(
 	text: string,
 	tagName: string,
 ): string | null {
-	const pattern = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`, "i");
+	// Escape tagName to prevent ReDoS attacks from special regex characters
+	const escapedTag = escapeRegExp(tagName);
+	const pattern = new RegExp(
+		`<${escapedTag}>([\\s\\S]*?)</${escapedTag}>`,
+		"i",
+	);
 	const match = text.match(pattern);
 	const content = match?.[1]?.trim() ?? null;
 	// Sanitize to remove any binary/control characters

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -205,6 +205,9 @@ export function extractTagContent(
 
 	for (let i = 0; i < tagName.length; i++) {
 		const char = tagName[i];
+		if (char === undefined) {
+			return null;
+		}
 		const isValid =
 			(char >= "a" && char <= "z") ||
 			(char >= "A" && char <= "Z") ||


### PR DESCRIPTION
## Summary
- Escape special regex characters in `tagName` parameter before constructing RegExp
- Prevents Regular Expression Denial-of-Service (ReDoS) attacks from malicious input

## Test plan
- [x] All 59 tests pass
- [x] TypeScript type check passes