### PR TITLE
feat: add `ralph watch` command for iterative repo discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -635,3 +635,10 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/linux,python,windows,macOS,VisualStudioCode,jetbrains+all,pycharm+all,node,amplify,sam,typescript,vue,idea,terraform,kubernetes,docker
 
 .claude
+
+# Project Watcher
+results/
+watch-manifest.json
+.kiro/settings/mcp.json
+.kiro/ralph-loop.local.json
+.kiro/ralph-session.json

--- a/.kiro/agents/project-watcher.json
+++ b/.kiro/agents/project-watcher.json
@@ -1,0 +1,20 @@
+{
+  "name": "project-watcher",
+  "description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
+  "tools": [
+    "read",
+    "write",
+    "@brave-search",
+    "@tavily",
+    "@exa"
+  ],
+  "allowedTools": [
+    "*"
+  ],
+  "includeMcpJson": true,
+  "resources": [
+    "file://../../watch-manifest.json",
+    "file://../ralph-loop.local.json"
+  ],
+  "prompt": "file://../steering/watcher-context.md"
+}

--- a/.kiro/prompts/opsx-apply.prompt.md
+++ b/.kiro/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.kiro/prompts/opsx-archive.prompt.md
+++ b/.kiro/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.kiro/prompts/opsx-explore.prompt.md
+++ b/.kiro/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.kiro/prompts/opsx-propose.prompt.md
+++ b/.kiro/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.kiro/skills/openspec-apply-change/SKILL.md
+++ b/.kiro/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.kiro/skills/openspec-archive-change/SKILL.md
+++ b/.kiro/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.kiro/skills/openspec-explore/SKILL.md
+++ b/.kiro/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.kiro/skills/openspec-propose/SKILL.md
+++ b/.kiro/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.kiro/steering/watcher-context.md
+++ b/.kiro/steering/watcher-context.md
@@ -1,0 +1,171 @@
+# Project Watcher - Iterative Discovery Loop
+
+You are a research agent in a Ralph Wiggum iterative loop. Your job is to discover trending GitHub repositories that match the topics and languages defined in the watch manifest.
+
+## How This Works
+
+1. You are in an iterative loop (max 10 iterations by default)
+2. Each iteration you go deeper into research
+3. Your findings accumulate in the results folder across iterations
+4. When research is saturated, signal completion with `<promise>COMPLETE</promise>`
+
+## Setup
+
+Read these files at the START of every iteration:
+
+- `watch-manifest.json` - Topics, languages, watched repos, and thresholds
+- `.kiro/ralph-loop.local.json` - Loop state (iteration number, previous feedback)
+- The results folder path is provided in your prompt
+
+## Research Strategy by Phase
+
+### Early Iterations (1-3): Broad Discovery
+
+Cast a wide net across all search tools:
+
+**Using @exa (best for code/repo discovery):**
+- Search for GitHub repos matching each topic
+- Look for recently created repos with growing stars
+- Search for repos by language + topic combinations
+
+**Using @brave-search (best for community signals):**
+- Search Hacker News for "Show HN" posts linking to GitHub repos
+- Search Reddit (r/programming, r/opensource, r/github) for repo links
+- Search Product Hunt for developer tool launches
+- Search Lobsters for trending technical projects
+
+**Using @tavily (best for articles and announcements):**
+- Search dev.to for #opensource and #showdev tagged articles
+- Search for blog posts announcing new tools and frameworks
+- Search for "awesome list" additions in your topic areas
+
+For each candidate repo found, record:
+- Full repo name (owner/repo)
+- GitHub URL
+- Description
+- Star count (if available)
+- Primary language
+- Which search tool found it
+- Why it's relevant to the manifest topics
+
+**Deduplication:** Check each candidate against the existing `watch` list in the manifest. Skip repos already being watched.
+
+### Mid Iterations (4-7): Deep Dives + Adjacent Exploration
+
+Focus on the most interesting discoveries from earlier iterations:
+
+- Analyze top repos: read their READMEs via search, understand architecture and purpose
+- Explore the author's other repositories for related work
+- Find competing/alternative projects solving similar problems
+- Look for ecosystem patterns: are multiple repos converging on a new approach?
+- Check community traction: GitHub discussions, blog reactions, HN comment quality
+- Surface NEW concepts and categories not in the original topic list
+
+### Late Iterations (8-10): Synthesis + Completion
+
+- Compare and contrast discoveries across categories
+- Identify the most significant finds and articulate why they matter
+- Write the final summary with clear categories and rankings
+- Assess which repos should be auto-added to the watch list (above threshold)
+- Note open questions and leads for future discovery runs
+- Signal completion when no significant new leads remain
+
+## Output Files
+
+Write these files to the results folder (path given in your prompt):
+
+### Per Iteration: `iterations/NN-description.md`
+
+After each iteration, write a snapshot markdown file:
+
+```
+# Iteration N: [Brief Description]
+
+## What Was Explored
+- Search queries run and sources checked
+
+## Key Findings
+- Notable repos discovered with brief analysis
+
+## New Research Questions
+- Questions generated for next iteration
+
+## Sources
+- Links to search results, articles, discussions
+```
+
+### Accumulating: `discovery.json`
+
+Update this file each iteration. Add new discoveries, deepen analysis of existing ones:
+
+```json
+{
+  "taskId": "FROM_PROMPT",
+  "iterationsCompleted": N,
+  "timestamp": "ISO_DATE",
+  "discoveries": [
+    {
+      "repo": "owner/name",
+      "url": "https://github.com/owner/name",
+      "description": "...",
+      "stars": 123,
+      "language": "Python",
+      "topics": ["topic1", "topic2"],
+      "sources": ["exa", "brave-search"],
+      "discoveredIteration": 1,
+      "depth": "shallow|medium|deep",
+      "analysis": "Detailed analysis from deep dive...",
+      "adjacentTo": ["related/repo"],
+      "reasoning": "Why this repo matters...",
+      "autoAdded": false
+    }
+  ],
+  "conceptsExplored": ["concept1", "concept2"],
+  "researchQuestionsAnswered": ["question -> answer"],
+  "stats": {
+    "totalSearched": 150,
+    "totalDiscovered": 12,
+    "autoAdded": 3,
+    "sourcesUsed": ["exa", "brave-search", "tavily"]
+  }
+}
+```
+
+### Final: `summary.md`
+
+Write this on your LAST iteration (when signaling completion):
+
+```markdown
+# Discovery Summary - [Date]
+
+## Top Discoveries
+Ranked list of the most significant repos found.
+
+## By Category
+Group discoveries by topic/theme.
+
+## Emerging Patterns
+Trends and patterns observed across discoveries.
+
+## Recommended for Watch List
+Repos that meet auto-add thresholds.
+
+## Open Questions
+Leads for future discovery runs.
+```
+
+## Completion Rules
+
+- **Min iterations (3):** Do NOT signal completion before iteration 3
+- **Signal completion** when: all topics explored, no significant new leads, research questions answered
+- **Always output feedback** at the end of every iteration using `<ralph-feedback>` XML
+- Focus `<next-steps>` on concrete research questions for the next iteration
+- Focus `<ideas>` on speculative leads worth pursuing
+
+## Important
+
+- Read the manifest FIRST every iteration to stay aligned with topics
+- Check previous iteration results to avoid duplicate work
+- Prioritize repos created in the last 30 days (configurable via manifest thresholds)
+- Star count alone is not enough — look for novelty, unique approaches, and community buzz
+- When in doubt about a repo's relevance, include it with reasoning

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,28 @@
+{
+	"mcpServers": {
+		"brave-search": {
+			"command": "npx",
+			"args": ["-y", "@brave/brave-search-mcp-server"],
+			"env": {
+				"BRAVE_API_KEY": "${BRAVE_API_KEY}"
+			},
+			"autoApprove": ["*"]
+		},
+		"tavily": {
+			"command": "npx",
+			"args": ["-y", "tavily-mcp@latest"],
+			"env": {
+				"TAVILY_API_KEY": "${TAVILY_API_KEY}"
+			},
+			"autoApprove": ["*"]
+		},
+		"exa": {
+			"command": "npx",
+			"args": ["-y", "exa-mcp-server"],
+			"env": {
+				"EXA_API_KEY": "${EXA_API_KEY}"
+			},
+			"autoApprove": ["*"]
+		}
+	}
+}

--- a/.openspec/specs/watch-command/spec.md
+++ b/.openspec/specs/watch-command/spec.md
@@ -1,0 +1,116 @@
+# Spec: Watch Command
+
+## Summary
+
+Add a `ralph watch` command that discovers trending GitHub repositories through iterative deep research using Kiro CLI with existing MCP search servers (exa, brave-search, tavily).
+
+## Requirements
+
+### REQ-1: Watch Run (Default Action)
+When the user runs `ralph watch`, the system SHALL:
+- Generate a unique task ID (format: `pw-YYYYMMDD-HHmm`)
+- Create a results directory at `results/<task-id>/` with an `iterations/` subdirectory
+- Read `watch-manifest.json` for topics, languages, and thresholds
+- Build a prompt containing the manifest contents and results folder path
+- Start a ralph loop (min 3, max 10 iterations) using the `project-watcher` Kiro agent
+- Write a `status.json` file tracking run progress
+- Support `--max-iterations` and `--min-iterations` flags to override defaults
+
+### REQ-2: Watch Init
+When the user runs `ralph watch init`, the system SHALL:
+- Create `.kiro/agents/project-watcher.json` (agent config)
+- Create `.kiro/steering/watcher-context.md` (steering file)
+- Create `.kiro/settings/mcp.json` from `.mcp.json.example` if it doesn't exist
+- Create `watch-manifest.json` from `watch-manifest.example.json` if it doesn't exist
+- Support `--force` to overwrite existing files
+
+### REQ-3: Watch Results
+When the user runs `ralph watch results [id]`, the system SHALL:
+- If no ID provided, show results from the most recent run
+- Read and display `summary.md` if the run is complete
+- Read and display `status.json` if the run is still in progress
+- Show iteration count and discovery count from status
+
+### REQ-4: Watch List
+When the user runs `ralph watch ls`, the system SHALL:
+- Scan the `results/` directory for task folders
+- Display each run with: task ID, status, iteration count, discovery count, timestamp
+- Sort by most recent first
+
+### REQ-5: Results File Structure
+Each watch run SHALL produce:
+- `results/<task-id>/status.json` - Run metadata and status
+- `results/<task-id>/discovery.json` - Accumulated discoveries across iterations
+- `results/<task-id>/iterations/NN-description.md` - Per-iteration snapshots
+- `results/<task-id>/summary.md` - Final synthesis (on completion)
+
+### REQ-6: Manifest Schema
+The `watch-manifest.json` file SHALL contain:
+- `version` (string): Manifest version
+- `topics` (string[]): Topics of interest for discovery
+- `languages` (string[]): Programming languages to prioritize
+- `watch` (array): Currently watched repositories with repo, added date, source, and tags
+- `thresholds` (object): minStars, autoAddStars, maxAgeDays
+
+### REQ-8: Manifest Lifecycle — Growth
+The agent SHALL auto-add repos to `watch-manifest.json` when:
+- The repo exceeds the `autoAddStars` threshold
+- The repo is not already in the watch list
+- Auto-added entries SHALL include: `source: "discovered"`, `lastSeen`, `discoveryCount`, `runId`
+
+### REQ-9: Manifest Lifecycle — Freshness Tracking
+On each watch run, the agent SHALL:
+- Update `lastSeen` to the current date for every watched repo it encounters in search results
+- Increment `discoveryCount` for repos seen again
+- Freshness categories: Active (<30d), Stale (30-90d), Dormant (>90d)
+
+### REQ-10: Manifest Lifecycle — Pruning Suggestions
+The agent SHALL NOT auto-remove repos. Instead it SHALL:
+- Flag `source: "discovered"` repos where `lastSeen` exceeds 90 days
+- Include a "Pruning Suggestions" section in `summary.md` with reasoning
+- Manual entries (`source: "manual"`) are never flagged for pruning
+
+### REQ-11: Discovery Log
+The manifest SHALL include a `discoveryLog` array (capped at 50 entries) with:
+- `runId`, `date`, `reposAdded`, `reposUpdated`, `pruningSuggested`
+
+### REQ-7: Open Source Safety
+The repository SHALL NOT commit:
+- API keys or secrets
+- `.kiro/settings/mcp.json` (contains API key references)
+- `watch-manifest.json` (user-specific)
+- `results/` directory (run outputs)
+
+The repository SHALL provide:
+- `.mcp.json.example` with placeholder env var references
+- `watch-manifest.example.json` with sample topics
+
+## Design Decisions
+
+See `docs/adr/` for architectural decision records:
+- ADR-001: Watch command architecture (reuse existing loop runner)
+- ADR-002: Iterative deepening research strategy
+- ADR-003: Reuse existing MCP servers (no custom MCP)
+- ADR-004: Manifest lifecycle — growth, staleness, and pruning
+
+## Files Changed
+
+### New Files
+- `src/commands/watch.ts` - Watch command handlers
+- `src/core/watch-runner.ts` - Watch-specific loop orchestration
+- `src/schemas/manifest.ts` - Manifest Zod schema
+- `src/schemas/results.ts` - Results Zod schemas
+- `src/data/project-watcher.json` - Kiro agent config template
+- `src/data/watcher-context.md` - Steering file template
+- `.mcp.json.example` - Example MCP server config
+- `watch-manifest.example.json` - Example watch manifest
+- `docs/adr/001-watch-command-architecture.md`
+- `docs/adr/002-iterative-deepening-research.md`
+- `docs/adr/003-reuse-existing-mcp-servers.md`
+
+### Modified Files
+- `src/index.ts` - Register watch command
+- `src/commands/index.ts` - Export watch command
+- `src/schemas/index.ts` - Export new schemas
+- `src/utils/paths.ts` - Add watch-specific path constants
+- `.gitignore` - Add results/, mcp.json, watch-manifest.json

--- a/docs/adr/001-watch-command-architecture.md
+++ b/docs/adr/001-watch-command-architecture.md
@@ -1,0 +1,30 @@
+# ADR-001: Watch Command Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+We need a way to discover trending GitHub repositories matching specific topics and languages. The discovery should run overnight (fire-and-forget) and produce results retrievable by task ID the next morning.
+
+Ralph-for-kiro already provides an iterative loop mechanism with completion promises, feedback extraction, and Kiro CLI subprocess management. We need to decide how to integrate the watch functionality.
+
+## Decision
+
+Add a `ralph watch` command that reuses the existing loop runner infrastructure. The watch command:
+
+- Generates a task ID (e.g. `pw-20260318-2200`) and creates a results folder
+- Reads a `watch-manifest.json` for topics, languages, and thresholds
+- Builds a prompt with manifest context and instructs the Kiro agent to write results
+- Delegates to the existing `runLoop()` with watch-specific defaults (min 3, max 10 iterations)
+- The Kiro agent writes `discovery.json`, iteration snapshots, and `summary.md` directly to the results folder
+
+Subcommands: `ralph watch` (run), `ralph watch init`, `ralph watch results [id]`, `ralph watch ls`.
+
+## Consequences
+
+- Reuses all existing loop infrastructure (loop-runner, kiro-client, session-reader, feedback extraction)
+- Watch-specific code is isolated in `src/commands/watch.ts` and `src/core/watch-runner.ts`
+- The Kiro agent is responsible for writing results files (not the TypeScript CLI), keeping the CLI thin
+- Results are file-based and git-trackable

--- a/docs/adr/002-iterative-deepening-research.md
+++ b/docs/adr/002-iterative-deepening-research.md
@@ -1,0 +1,29 @@
+# ADR-002: Iterative Deepening via Ralph Loop
+
+## Status
+
+Accepted
+
+## Context
+
+A single-pass discovery scan is shallow. It finds repos but doesn't analyze them deeply, explore adjacent concepts, or follow citation chains. We need depth, not just breadth.
+
+## Decision
+
+Use ralph's iterative loop with completion promise as an iterative deepening research mechanism. Each iteration builds on the last:
+
+- **Iterations 1-3 (Discovery):** Broad search across topics using MCP tools, find candidates, generate research questions
+- **Iterations 4-7 (Deep Dive):** Analyze top repos, follow the graph (author's other work, competitors, related projects), surface adjacent concepts
+- **Iterations 8-10 (Synthesis):** Compare approaches, identify patterns, write final summary, signal completion
+
+Ralph's XML feedback mechanism (`<ralph-feedback>`) carries `nextSteps`, `ideas`, and `blockers` forward between iterations via the state file. This gives each new Kiro session full context of prior research.
+
+The agent signals `<promise>COMPLETE</promise>` when research is saturated (no significant new leads) or when max iterations (default 10) is reached.
+
+## Consequences
+
+- Deep research emerges naturally from the loop — no special orchestration needed
+- The steering file guides the research arc (broad → deep → synthesis)
+- Each iteration snapshot is preserved in `results/<task-id>/iterations/`
+- Quality improves with more iterations; the min-iterations setting (default 3) prevents premature completion
+- Cost scales linearly with iterations — users can tune depth via `--max-iterations`

--- a/docs/adr/003-reuse-existing-mcp-servers.md
+++ b/docs/adr/003-reuse-existing-mcp-servers.md
@@ -1,0 +1,29 @@
+# ADR-003: Reuse Existing MCP Servers
+
+## Status
+
+Accepted
+
+## Context
+
+The watch command needs web search capabilities to discover trending repos across GitHub, Hacker News, Reddit, Product Hunt, and other sources. We considered building a custom MCP server vs. reusing existing ones.
+
+## Decision
+
+Reuse existing, well-maintained MCP servers: **exa**, **brave-search**, and **tavily**. These are configured as stdio MCP servers in `.kiro/settings/mcp.json` using the same `npx -y` pattern established in personal-plugins.
+
+- **exa** (`exa-mcp-server`): Strong at code/repository discovery, GitHub-specific search
+- **brave-search** (`@brave/brave-search-mcp-server`): Good for HN, Reddit, Product Hunt, general web
+- **tavily** (`tavily-mcp@latest`): Research-focused, good for blog posts, dev.to, announcements
+
+No custom MCP server is built. The Kiro agent's steering file instructs it on how to use these tools effectively for repo discovery.
+
+Since API keys are sensitive, the repo ships a `.mcp.json.example` with placeholder values. Users copy it to `.kiro/settings/mcp.json` and fill in their own keys.
+
+## Consequences
+
+- Zero custom MCP code to maintain
+- Leverages battle-tested search APIs
+- Users need their own API keys (exa, brave, tavily)
+- The Kiro agent's steering file is the "glue" that orchestrates the search strategy
+- Adding new search sources means adding a new MCP server to the config, not writing code

--- a/docs/adr/004-manifest-lifecycle.md
+++ b/docs/adr/004-manifest-lifecycle.md
@@ -1,0 +1,88 @@
+# ADR-004: Manifest Lifecycle — Growth, Staleness, and Pruning
+
+## Status
+
+Accepted
+
+## Context
+
+The watch manifest (`watch-manifest.json`) starts with a handful of manually-added repos and topics. Over multiple discovery runs, the agent finds new repos. The manifest needs to evolve as a living document — growing when the agent discovers high-signal repos, tracking freshness so the user knows what's active, and eventually pruning repos that are no longer relevant.
+
+Without lifecycle management, the manifest either stays static (user must manually curate) or grows unbounded (agent adds everything, signal drowns in noise).
+
+## Decision
+
+### Growth: Auto-Add with Provenance
+
+When the agent discovers a repo that exceeds the `autoAddStars` threshold during a watch run, it adds it to the manifest's `watch` array with full provenance:
+
+```json
+{
+  "repo": "owner/name",
+  "added": "2026-03-18",
+  "source": "discovered",
+  "tags": ["ai-agents", "mcp"],
+  "lastSeen": "2026-03-18",
+  "discoveryCount": 1,
+  "runId": "pw-20260318-2200"
+}
+```
+
+- `source: "discovered"` distinguishes auto-added repos from manual entries
+- `lastSeen` tracks when the repo last appeared in a discovery run
+- `discoveryCount` tracks how many runs have surfaced this repo (cross-source signal)
+- `runId` records which run discovered it
+
+Manual entries (`source: "manual"`) are never auto-removed. They are the user's explicit intent.
+
+### Freshness: Last-Seen Tracking
+
+On every watch run, the agent updates `lastSeen` for repos it encounters across its searches. This happens whether or not the repo is new — existing watch entries get their `lastSeen` bumped and `discoveryCount` incremented.
+
+A repo's freshness is derived from `lastSeen` relative to the current date:
+- **Active**: seen in the last 30 days
+- **Stale**: not seen in 30-90 days
+- **Dormant**: not seen in 90+ days
+
+### Pruning: Agent-Suggested, User-Confirmed
+
+The agent does NOT auto-remove repos. Instead, at the end of each run it:
+
+1. Flags repos where `source: "discovered"` AND `lastSeen` is stale (>90 days)
+2. Writes a `pruning-suggestions` section in the run summary
+3. Lists the candidate repos with reasoning (no recent activity, low star velocity, superseded by alternatives)
+
+The user reviews and manually removes entries, or runs `ralph watch prune` to accept all suggestions.
+
+This is intentionally conservative — removing a repo from the watch list is a destructive action that should require human judgment.
+
+### Discovery Log: Append-Only History
+
+Each watch run appends to `watch-manifest.json`'s `discoveryLog` array:
+
+```json
+{
+  "discoveryLog": [
+    {
+      "runId": "pw-20260318-2200",
+      "date": "2026-03-18",
+      "reposAdded": 3,
+      "reposUpdated": 8,
+      "reposSuggested": 5,
+      "pruningSuggested": 1
+    }
+  ]
+}
+```
+
+This gives the user a timeline of how the manifest evolved. The log is capped at the last 50 entries to prevent unbounded growth.
+
+## Consequences
+
+- The manifest is a living document that gets richer over time
+- Manual entries are sacred — never auto-modified or removed
+- Discovered entries carry full provenance for auditability
+- Staleness is visible in the manifest itself (users can grep for stale repos)
+- Pruning requires human confirmation, preventing accidental data loss
+- The discovery log provides accountability for how the manifest evolved
+- Git-tracking the manifest shows the full history of changes via diffs

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,3 +8,9 @@ export { cancelCommand } from "./cancel";
 export { initCommand } from "./init";
 export { loopCommand } from "./loop";
 export { resumeCommand } from "./resume";
+export {
+	watchInitCommand,
+	watchLsCommand,
+	watchResultsCommand,
+	watchRunCommand,
+} from "./watch";

--- a/src/commands/loop.ts
+++ b/src/commands/loop.ts
@@ -53,5 +53,6 @@ export async function loopCommand(
 		process.exit(1);
 	}
 
-	await runLoop(result.data);
+	const loopResult = await runLoop(result.data);
+	process.exit(loopResult.reason === "completed" ? 0 : 0);
 }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -97,7 +97,8 @@ export async function resumeCommand(opts: ResumeOptions): Promise<void> {
 		process.exit(1);
 	}
 
-	await runLoop(result.data);
+	const loopResult = await runLoop(result.data);
+	process.exit(loopResult.reason === "completed" ? 0 : 0);
 }
 
 /**

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,0 +1,261 @@
+/**
+ * @fileoverview Watch command for Ralph Wiggum CLI.
+ * Discovers trending repos through iterative deep research.
+ * @module commands/watch
+ */
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "@clack/prompts";
+import pc from "picocolors";
+import {
+	listRuns,
+	readStatus,
+	readSummary,
+	runWatch,
+} from "../core/watch-runner";
+import agentConfig from "../data/project-watcher.json";
+import steeringContent from "../data/watcher-context.md" with { type: "text" };
+import {
+	KIRO_AGENTS_DIR,
+	KIRO_SETTINGS_DIR,
+	KIRO_STEERING_DIR,
+	RESULTS_DIR,
+	WATCH_MANIFEST_FILE,
+} from "../utils/paths";
+
+/**
+ * CLI options for the watch run command.
+ */
+interface WatchRunOptions {
+	minIterations: string;
+	maxIterations: string;
+	agent?: string;
+}
+
+/**
+ * CLI options for the watch init command.
+ */
+interface WatchInitOptions {
+	force?: boolean;
+}
+
+/**
+ * Runs a watch discovery loop.
+ * Default action when `ralph watch` is invoked without subcommand.
+ */
+export async function watchRunCommand(opts: WatchRunOptions): Promise<void> {
+	const minIterations = Number.parseInt(opts.minIterations, 10);
+	const maxIterations = Number.parseInt(opts.maxIterations, 10);
+
+	if (Number.isNaN(minIterations) || minIterations < 1) {
+		log.error(pc.red("Invalid --min-iterations value"));
+		process.exit(1);
+	}
+	if (Number.isNaN(maxIterations) || maxIterations < 1) {
+		log.error(pc.red("Invalid --max-iterations value"));
+		process.exit(1);
+	}
+
+	await runWatch({
+		minIterations,
+		maxIterations,
+		agentName: opts.agent ?? null,
+	});
+}
+
+/**
+ * Initializes watch configuration files.
+ */
+export async function watchInitCommand(opts: WatchInitOptions): Promise<void> {
+	const agentPath = join(KIRO_AGENTS_DIR, "project-watcher.json");
+	const steeringPath = join(KIRO_STEERING_DIR, "watcher-context.md");
+	const mcpSourcePath = ".mcp.json.example";
+	const mcpTargetPath = join(KIRO_SETTINGS_DIR, "mcp.json");
+	const manifestSourcePath = "watch-manifest.example.json";
+
+	// Check for existing files
+	if (!opts.force) {
+		const existing: string[] = [];
+		if (await Bun.file(agentPath).exists()) existing.push(agentPath);
+		if (await Bun.file(steeringPath).exists()) existing.push(steeringPath);
+
+		if (existing.length > 0) {
+			log.error(pc.red("Files already exist:"));
+			for (const f of existing) {
+				log.message(`  - ${f}`);
+			}
+			log.message(`\nUse ${pc.bold("--force")} to overwrite.`);
+			return;
+		}
+	}
+
+	// Create directories
+	await mkdir(KIRO_AGENTS_DIR, { recursive: true });
+	await mkdir(KIRO_STEERING_DIR, { recursive: true });
+	await mkdir(KIRO_SETTINGS_DIR, { recursive: true });
+	await mkdir(RESULTS_DIR, { recursive: true });
+
+	// Write agent config
+	await Bun.write(agentPath, `${JSON.stringify(agentConfig, null, 2)}\n`);
+	log.success(`${pc.green("Created")} ${agentPath}`);
+
+	// Write steering file
+	await Bun.write(steeringPath, steeringContent);
+	log.success(`${pc.green("Created")} ${steeringPath}`);
+
+	// Copy MCP config if it doesn't exist
+	if (!(await Bun.file(mcpTargetPath).exists())) {
+		const mcpSource = Bun.file(mcpSourcePath);
+		if (await mcpSource.exists()) {
+			const mcpContent = await mcpSource.text();
+			await Bun.write(mcpTargetPath, mcpContent);
+			log.success(`${pc.green("Created")} ${mcpTargetPath}`);
+			log.message(
+				pc.dim(
+					"  Edit this file to add your API keys (BRAVE_API_KEY, TAVILY_API_KEY, EXA_API_KEY)",
+				),
+			);
+		}
+	} else {
+		log.message(pc.dim(`  ${mcpTargetPath} already exists, skipping`));
+	}
+
+	// Copy manifest if it doesn't exist
+	if (!(await Bun.file(WATCH_MANIFEST_FILE).exists())) {
+		const manifestSource = Bun.file(manifestSourcePath);
+		if (await manifestSource.exists()) {
+			const manifestContent = await manifestSource.text();
+			await Bun.write(WATCH_MANIFEST_FILE, manifestContent);
+			log.success(`${pc.green("Created")} ${WATCH_MANIFEST_FILE}`);
+			log.message(pc.dim("  Edit this file to set your topics and languages"));
+		}
+	} else {
+		log.message(pc.dim(`  ${WATCH_MANIFEST_FILE} already exists, skipping`));
+	}
+
+	// Success message
+	console.log();
+	log.success(pc.bold(pc.green("Project Watcher initialized!")));
+	console.log();
+	log.message("Next steps:");
+	log.message(
+		pc.dim("  1. Edit watch-manifest.json to set your topics and languages"),
+	);
+	log.message(pc.dim("  2. Edit .kiro/settings/mcp.json with your API keys"));
+	log.message(pc.dim("  3. Run: ralph watch"));
+}
+
+/**
+ * Displays results for a specific watch run.
+ */
+export async function watchResultsCommand(taskId?: string): Promise<void> {
+	let targetId = taskId;
+
+	// If no ID provided, find the most recent run
+	if (!targetId) {
+		const runs = await listRuns();
+		if (runs.length === 0) {
+			log.message("No watch runs found. Run 'ralph watch' to start one.");
+			return;
+		}
+		const latest = runs[0];
+		if (!latest) {
+			log.message("No watch runs found.");
+			return;
+		}
+		targetId = latest.taskId;
+		log.message(pc.dim(`Showing most recent run: ${targetId}`));
+		console.log();
+	}
+
+	// Read status
+	const status = await readStatus(targetId);
+	if (!status) {
+		log.error(pc.red(`No results found for task ${targetId}`));
+		return;
+	}
+
+	// Display status
+	const statusColor =
+		status.status === "complete"
+			? pc.green
+			: status.status === "failed"
+				? pc.red
+				: pc.yellow;
+
+	log.info(pc.bold(`Task: ${status.taskId}`));
+	log.message(`   Status: ${statusColor(status.status)}`);
+	log.message(`   Started: ${status.startedAt}`);
+	if (status.completedAt) {
+		log.message(`   Completed: ${status.completedAt}`);
+	}
+	log.message(
+		`   Iterations: ${status.currentIteration}/${status.maxIterations}`,
+	);
+	log.message(`   Repos discovered: ${status.reposDiscovered}`);
+	log.message(`   Repos added: ${status.reposAdded}`);
+
+	if (status.error) {
+		log.error(pc.red(`   Error: ${status.error}`));
+	}
+
+	// Show summary if complete
+	if (status.status === "complete") {
+		const summary = await readSummary(targetId);
+		if (summary) {
+			console.log();
+			log.info(pc.bold("Summary:"));
+			console.log(summary);
+		}
+	}
+
+	// Show iteration files
+	const iterationsDir = join(RESULTS_DIR, targetId, "iterations");
+	try {
+		const files = await readdir(iterationsDir);
+		if (files.length > 0) {
+			console.log();
+			log.message(pc.dim(`Iteration snapshots in ${iterationsDir}:`));
+			for (const f of files.sort()) {
+				log.message(pc.dim(`  - ${f}`));
+			}
+		}
+	} catch {
+		// No iterations dir yet
+	}
+}
+
+/**
+ * Lists recent watch runs.
+ */
+export async function watchLsCommand(): Promise<void> {
+	const runs = await listRuns();
+
+	if (runs.length === 0) {
+		log.message("No watch runs found. Run 'ralph watch' to start one.");
+		return;
+	}
+
+	log.info(pc.bold(`${runs.length} watch run(s):`));
+	console.log();
+
+	for (const run of runs) {
+		const statusColor =
+			run.status === "complete"
+				? pc.green
+				: run.status === "failed"
+					? pc.red
+					: pc.yellow;
+
+		const date = new Date(run.startedAt).toLocaleDateString("en-US", {
+			month: "short",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+
+		log.message(
+			`  ${pc.bold(run.taskId)}  ${statusColor(run.status.padEnd(8))}  ${date}  ${run.reposDiscovered} repos`,
+		);
+	}
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./kiro-client";
 export * from "./loop-runner";
 export * from "./session-reader";
+export * from "./watch-runner";

--- a/src/core/loop-runner.ts
+++ b/src/core/loop-runner.ts
@@ -20,23 +20,36 @@ import { KiroClient } from "./kiro-client";
 import { getLatestSession } from "./session-reader";
 
 /**
+ * Result of a loop execution.
+ */
+export interface LoopResult {
+	/** Why the loop ended */
+	reason: "completed" | "max-iterations" | "interrupted";
+	/** Final iteration number */
+	iteration: number;
+	/** Feedback from the last iteration */
+	feedback?: RalphFeedback;
+}
+
+/**
  * Runs the Ralph Wiggum iterative loop.
  * Executes kiro-cli repeatedly until the completion promise is detected
  * or maximum iterations are reached.
  * @param config - Loop configuration with prompt and iteration settings
- * @returns Resolves when the loop completes, is interrupted, or reaches max iterations
+ * @returns The loop result with reason, iteration count, and last feedback
  * @example
  * ```typescript
- * await runLoop({
+ * const result = await runLoop({
  *   prompt: "Build a REST API",
  *   minIterations: 1,
  *   maxIterations: 10,
  *   completionPromise: "DONE",
  *   agentName: null
  * });
+ * console.log(result.reason); // "completed" | "max-iterations"
  * ```
  */
-export async function runLoop(config: LoopConfig): Promise<void> {
+export async function runLoop(config: LoopConfig): Promise<LoopResult> {
 	const client = new KiroClient(config.agentName);
 	const cwd = process.cwd();
 
@@ -170,7 +183,11 @@ export async function runLoop(config: LoopConfig): Promise<void> {
 					log.success(pc.green(`Completed at iteration ${iteration}!`));
 					// Task completed successfully - can delete state
 					await cleanup();
-					process.exit(0);
+					return {
+						reason: "completed",
+						iteration,
+						feedback: previousFeedback,
+					};
 				}
 			} else {
 				log.message(
@@ -186,7 +203,11 @@ export async function runLoop(config: LoopConfig): Promise<void> {
 				log.message("Saving state for resume...");
 				await cleanup(iteration, previousFeedback);
 				log.message("Run 'ralph resume' to continue where you left off.");
-				process.exit(0);
+				return {
+					reason: "max-iterations",
+					iteration,
+					feedback: previousFeedback,
+				};
 			}
 		}
 	} catch (error) {
@@ -195,4 +216,6 @@ export async function runLoop(config: LoopConfig): Promise<void> {
 			throw error;
 		}
 	}
+
+	return { reason: "interrupted", iteration, feedback: previousFeedback };
 }

--- a/src/core/watch-runner.ts
+++ b/src/core/watch-runner.ts
@@ -1,0 +1,240 @@
+/**
+ * @fileoverview Watch-specific runner that wraps the loop runner.
+ * Manages task IDs, results folders, manifest reading, and prompt building.
+ * @module core/watch-runner
+ */
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "@clack/prompts";
+import pc from "picocolors";
+import { LoopConfigSchema } from "../schemas/config";
+import { type WatchManifest, WatchManifestSchema } from "../schemas/manifest";
+import { type WatchStatus, WatchStatusSchema } from "../schemas/results";
+import {
+	RESULTS_DIR,
+	WATCH_AGENT_NAME,
+	WATCH_MANIFEST_FILE,
+} from "../utils/paths";
+import { runLoop } from "./loop-runner";
+
+/**
+ * Options for a watch run.
+ */
+export interface WatchRunOptions {
+	/** Minimum iterations before checking completion */
+	minIterations: number;
+	/** Maximum iterations */
+	maxIterations: number;
+	/** Optional agent name override */
+	agentName?: string | null;
+}
+
+/**
+ * Generates a task ID based on the current timestamp.
+ * Format: pw-YYYYMMDD-HHmm
+ */
+export function generateTaskId(): string {
+	const now = new Date();
+	const date = now.toISOString().slice(0, 10).replace(/-/g, "");
+	const time = `${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
+	return `pw-${date}-${time}`;
+}
+
+/**
+ * Reads and validates the watch manifest file.
+ */
+export async function readManifest(): Promise<WatchManifest> {
+	const file = Bun.file(WATCH_MANIFEST_FILE);
+
+	if (!(await file.exists())) {
+		throw new Error(
+			`Watch manifest not found at ${WATCH_MANIFEST_FILE}\nRun 'ralph watch init' first.`,
+		);
+	}
+
+	const content = await file.json();
+	return WatchManifestSchema.parse(content);
+}
+
+/**
+ * Builds the prompt for the Kiro agent from the manifest.
+ */
+function buildWatchPrompt(
+	manifest: WatchManifest,
+	taskId: string,
+	resultsPath: string,
+): string {
+	const watchedRepos = manifest.watch
+		.map((w) => `  - ${w.repo} (${w.tags.join(", ")})`)
+		.join("\n");
+
+	return `You are running a Project Watcher discovery scan.
+
+TASK ID: ${taskId}
+RESULTS FOLDER: ${resultsPath}
+
+Write all output files to the results folder above. Create the iterations/ subdirectory as needed.
+
+WATCH MANIFEST:
+- Topics: ${manifest.topics.join(", ")}
+- Languages: ${manifest.languages.join(", ")}
+- Min stars threshold: ${manifest.thresholds.minStars}
+- Auto-add threshold: ${manifest.thresholds.autoAddStars}
+- Max repo age: ${manifest.thresholds.maxAgeDays} days
+- Currently watching:
+${watchedRepos || "  (none)"}
+
+Search for trending GitHub repositories matching these topics using all available MCP tools (@exa, @brave-search, @tavily). Follow the iterative deepening strategy in your steering file.
+
+Read .kiro/ralph-loop.local.json for iteration state and previous feedback.`;
+}
+
+/**
+ * Writes or updates the status file for a watch run.
+ */
+async function writeStatus(
+	resultsPath: string,
+	status: WatchStatus,
+): Promise<void> {
+	const statusPath = join(resultsPath, "status.json");
+	await Bun.write(statusPath, JSON.stringify(status, null, 2));
+}
+
+/**
+ * Runs a watch discovery loop.
+ */
+export async function runWatch(opts: WatchRunOptions): Promise<void> {
+	// Read manifest
+	const manifest = await readManifest();
+
+	// Generate task ID and create results folder
+	const taskId = generateTaskId();
+	const resultsPath = join(RESULTS_DIR, taskId);
+	const iterationsPath = join(resultsPath, "iterations");
+
+	await mkdir(iterationsPath, { recursive: true });
+
+	// Write initial status
+	const status: WatchStatus = {
+		taskId,
+		status: "running",
+		startedAt: new Date().toISOString(),
+		completedAt: null,
+		currentIteration: 0,
+		maxIterations: opts.maxIterations,
+		reposDiscovered: 0,
+		reposAdded: 0,
+		error: null,
+	};
+	await writeStatus(resultsPath, status);
+
+	// Display startup info
+	log.info(pc.bold(pc.blue("Project Watcher starting")));
+	log.message(`   Task ID: ${pc.green(taskId)}`);
+	log.message(`   Topics: ${manifest.topics.join(", ")}`);
+	log.message(`   Languages: ${manifest.languages.join(", ")}`);
+	log.message(`   Results: ${resultsPath}`);
+	log.message(`   Iterations: ${opts.minIterations}-${opts.maxIterations}`);
+	console.log();
+
+	// Build the prompt
+	const prompt = buildWatchPrompt(manifest, taskId, resultsPath);
+
+	// Validate and run the loop
+	const config = LoopConfigSchema.parse({
+		prompt,
+		minIterations: opts.minIterations,
+		maxIterations: opts.maxIterations,
+		completionPromise: "COMPLETE",
+		agentName: opts.agentName ?? WATCH_AGENT_NAME,
+	});
+
+	try {
+		const result = await runLoop(config);
+
+		// Update status based on loop result
+		status.status = "complete";
+		status.completedAt = new Date().toISOString();
+		status.currentIteration = result.iteration;
+		await writeStatus(resultsPath, status);
+
+		log.success(
+			pc.green(`Watch run ${result.reason} at iteration ${result.iteration}`),
+		);
+		log.message(`Results: ${resultsPath}`);
+	} catch (error) {
+		// Update status on failure
+		status.status = "failed";
+		status.completedAt = new Date().toISOString();
+		status.error = error instanceof Error ? error.message : String(error);
+		await writeStatus(resultsPath, status);
+		throw error;
+	}
+}
+
+/**
+ * Reads the status file for a given task ID.
+ */
+export async function readStatus(taskId: string): Promise<WatchStatus | null> {
+	const statusPath = join(RESULTS_DIR, taskId, "status.json");
+	const file = Bun.file(statusPath);
+
+	if (!(await file.exists())) {
+		return null;
+	}
+
+	const content = await file.json();
+	return WatchStatusSchema.parse(content);
+}
+
+/**
+ * Reads the summary file for a given task ID.
+ */
+export async function readSummary(taskId: string): Promise<string | null> {
+	const summaryPath = join(RESULTS_DIR, taskId, "summary.md");
+	const file = Bun.file(summaryPath);
+
+	if (!(await file.exists())) {
+		return null;
+	}
+
+	return file.text();
+}
+
+/**
+ * Lists all watch runs in the results directory.
+ */
+export async function listRuns(): Promise<WatchStatus[]> {
+	// Check if results directory exists
+	try {
+		await readdir(RESULTS_DIR);
+	} catch {
+		return [];
+	}
+
+	const entries = await readdir(RESULTS_DIR);
+	const runs: WatchStatus[] = [];
+
+	for (const entry of entries) {
+		if (!entry.startsWith("pw-")) continue;
+
+		const statusPath = join(RESULTS_DIR, entry, "status.json");
+		const statusFile = Bun.file(statusPath);
+
+		if (await statusFile.exists()) {
+			try {
+				const content = await statusFile.json();
+				runs.push(WatchStatusSchema.parse(content));
+			} catch {
+				// Skip invalid status files
+			}
+		}
+	}
+
+	// Sort by start time, most recent first
+	runs.sort(
+		(a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+	);
+
+	return runs;
+}

--- a/src/data/project-watcher.json
+++ b/src/data/project-watcher.json
@@ -1,0 +1,12 @@
+{
+	"name": "project-watcher",
+	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
+	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
+	"allowedTools": ["*"],
+	"includeMcpJson": true,
+	"resources": [
+		"file://../../watch-manifest.json",
+		"file://../ralph-loop.local.json"
+	],
+	"prompt": "file://../steering/watcher-context.md"
+}

--- a/src/data/watcher-context.md
+++ b/src/data/watcher-context.md
@@ -1,0 +1,216 @@
+# Project Watcher - Iterative Discovery Loop
+
+You are a research agent in a Ralph Wiggum iterative loop. Your job is to discover trending GitHub repositories that match the topics and languages defined in the watch manifest.
+
+## How This Works
+
+1. You are in an iterative loop (max 10 iterations by default)
+2. Each iteration you go deeper into research
+3. Your findings accumulate in the results folder across iterations
+4. When research is saturated, signal completion with `<promise>COMPLETE</promise>`
+
+## Setup
+
+Read these files at the START of every iteration:
+
+- `watch-manifest.json` - Topics, languages, watched repos, and thresholds
+- `.kiro/ralph-loop.local.json` - Loop state (iteration number, previous feedback)
+- The results folder path is provided in your prompt
+
+## Research Strategy by Phase
+
+### Early Iterations (1-3): Broad Discovery
+
+Cast a wide net across all search tools:
+
+**Using @exa (best for code/repo discovery):**
+- Search for GitHub repos matching each topic
+- Look for recently created repos with growing stars
+- Search for repos by language + topic combinations
+
+**Using @brave-search (best for community signals):**
+- Search Hacker News for "Show HN" posts linking to GitHub repos
+- Search Reddit (r/programming, r/opensource, r/github) for repo links
+- Search Product Hunt for developer tool launches
+- Search Lobsters for trending technical projects
+
+**Using @tavily (best for articles and announcements):**
+- Search dev.to for #opensource and #showdev tagged articles
+- Search for blog posts announcing new tools and frameworks
+- Search for "awesome list" additions in your topic areas
+
+For each candidate repo found, record:
+- Full repo name (owner/repo)
+- GitHub URL
+- Description
+- Star count (if available)
+- Primary language
+- Which search tool found it
+- Why it's relevant to the manifest topics
+
+**Deduplication:** Check each candidate against the existing `watch` list in the manifest. Skip repos already being watched.
+
+### Mid Iterations (4-7): Deep Dives + Adjacent Exploration
+
+Focus on the most interesting discoveries from earlier iterations:
+
+- Analyze top repos: read their READMEs via search, understand architecture and purpose
+- Explore the author's other repositories for related work
+- Find competing/alternative projects solving similar problems
+- Look for ecosystem patterns: are multiple repos converging on a new approach?
+- Check community traction: GitHub discussions, blog reactions, HN comment quality
+- Surface NEW concepts and categories not in the original topic list
+
+### Late Iterations (8-10): Synthesis + Completion
+
+- Compare and contrast discoveries across categories
+- Identify the most significant finds and articulate why they matter
+- Write the final summary with clear categories and rankings
+- Assess which repos should be auto-added to the watch list (above threshold)
+- Note open questions and leads for future discovery runs
+- Signal completion when no significant new leads remain
+
+## Output Files
+
+Write these files to the results folder (path given in your prompt):
+
+### Per Iteration: `iterations/NN-description.md`
+
+After each iteration, write a snapshot markdown file:
+
+```
+# Iteration N: [Brief Description]
+
+## What Was Explored
+- Search queries run and sources checked
+
+## Key Findings
+- Notable repos discovered with brief analysis
+
+## New Research Questions
+- Questions generated for next iteration
+
+## Sources
+- Links to search results, articles, discussions
+```
+
+### Accumulating: `discovery.json`
+
+Update this file each iteration. Add new discoveries, deepen analysis of existing ones:
+
+```json
+{
+  "taskId": "FROM_PROMPT",
+  "iterationsCompleted": N,
+  "timestamp": "ISO_DATE",
+  "discoveries": [
+    {
+      "repo": "owner/name",
+      "url": "https://github.com/owner/name",
+      "description": "...",
+      "stars": 123,
+      "language": "Python",
+      "topics": ["topic1", "topic2"],
+      "sources": ["exa", "brave-search"],
+      "discoveredIteration": 1,
+      "depth": "shallow|medium|deep",
+      "analysis": "Detailed analysis from deep dive...",
+      "adjacentTo": ["related/repo"],
+      "reasoning": "Why this repo matters...",
+      "autoAdded": false
+    }
+  ],
+  "conceptsExplored": ["concept1", "concept2"],
+  "researchQuestionsAnswered": ["question -> answer"],
+  "stats": {
+    "totalSearched": 150,
+    "totalDiscovered": 12,
+    "autoAdded": 3,
+    "sourcesUsed": ["exa", "brave-search", "tavily"]
+  }
+}
+```
+
+### Final: `summary.md`
+
+Write this on your LAST iteration (when signaling completion):
+
+```markdown
+# Discovery Summary - [Date]
+
+## Top Discoveries
+Ranked list of the most significant repos found.
+
+## By Category
+Group discoveries by topic/theme.
+
+## Emerging Patterns
+Trends and patterns observed across discoveries.
+
+## Recommended for Watch List
+Repos that meet auto-add thresholds.
+
+## Pruning Suggestions
+Repos with `source: "discovered"` where `lastSeen` > 90 days ago.
+
+## Open Questions
+Leads for future discovery runs.
+```
+
+## Manifest Lifecycle — IMPORTANT
+
+You are responsible for keeping `watch-manifest.json` up to date. On your FINAL iteration:
+
+### Auto-Add (Growth)
+When you discover a repo that exceeds the `autoAddStars` threshold AND is not already in the `watch` array:
+- Add it to the `watch` array with these fields:
+  - `repo`: owner/name
+  - `added`: today's date (YYYY-MM-DD)
+  - `source`: "discovered"
+  - `tags`: relevant topic tags from the manifest
+  - `lastSeen`: today's date
+  - `discoveryCount`: 1
+  - `runId`: the task ID from your prompt
+
+### Freshness Tracking
+For every repo already in the `watch` array that you encounter in search results:
+- Update `lastSeen` to today's date
+- Increment `discoveryCount` by 1
+
+### Pruning Suggestions
+For repos where `source` is `"discovered"` and `lastSeen` is more than 90 days ago:
+- Do NOT remove them
+- List them in the "Pruning Suggestions" section of `summary.md` with reasoning
+- Manual entries (`source: "manual"`) are NEVER flagged
+
+### Discovery Log
+Append an entry to the `discoveryLog` array in the manifest:
+```json
+{
+  "runId": "TASK_ID",
+  "date": "YYYY-MM-DD",
+  "reposAdded": N,
+  "reposUpdated": N,
+  "pruningSuggested": N
+}
+```
+Cap the `discoveryLog` at 50 entries (remove oldest if needed).
+
+### Writing the Manifest
+After making changes, write the updated `watch-manifest.json` back to the project root. Preserve existing manual entries exactly as they are.
+
+## Completion Rules
+
+- **Min iterations (3):** Do NOT signal completion before iteration 3
+- **Signal completion** when: all topics explored, no significant new leads, research questions answered
+- **Always output feedback** at the end of every iteration using `<ralph-feedback>` XML
+- Focus `<next-steps>` on concrete research questions for the next iteration
+- Focus `<ideas>` on speculative leads worth pursuing
+
+## Important
+
+- Read the manifest FIRST every iteration to stay aligned with topics
+- Check previous iteration results to avoid duplicate work
+- Prioritize repos created in the last 30 days (configurable via manifest thresholds)
+- Star count alone is not enough — look for novelty, unique approaches, and community buzz
+- When in doubt about a repo's relevance, include it with reasoning

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import {
 	initCommand,
 	loopCommand,
 	resumeCommand,
+	watchInitCommand,
+	watchLsCommand,
+	watchResultsCommand,
+	watchRunCommand,
 } from "./commands";
 import { VERSION } from "./version";
 
@@ -73,5 +77,35 @@ program
 	)
 	.option("-a, --agent <name>", "Agent name (default: ralph-wiggum)")
 	.action(resumeCommand);
+
+// Watch command (with subcommands)
+const watchCmd = program
+	.command("watch")
+	.description("Discover trending repos through iterative deep research")
+	.option(
+		"-n, --min-iterations <number>",
+		"Minimum iterations before checking completion",
+		"3",
+	)
+	.option("-m, --max-iterations <number>", "Maximum iterations", "10")
+	.option("-a, --agent <name>", "Agent name override")
+	.action(watchRunCommand);
+
+watchCmd
+	.command("init")
+	.description("Initialize watch configuration (agent, steering, manifest)")
+	.option("-f, --force", "Overwrite existing files")
+	.action(watchInitCommand);
+
+watchCmd
+	.command("results")
+	.description("Show results for a watch run")
+	.argument("[id]", "Task ID (defaults to most recent)")
+	.action(watchResultsCommand);
+
+watchCmd
+	.command("ls")
+	.description("List recent watch runs")
+	.action(watchLsCommand);
 
 program.parse();

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,5 @@
 export * from "./config.ts";
+export * from "./manifest.ts";
+export * from "./results.ts";
 export * from "./session.ts";
 export * from "./state.ts";

--- a/src/schemas/manifest.ts
+++ b/src/schemas/manifest.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Watch manifest schema for project-watcher.
+ * Defines the structure of watch-manifest.json.
+ * @module schemas/manifest
+ */
+import { z } from "zod";
+
+/**
+ * Schema for a watched repository entry.
+ */
+export const WatchEntrySchema = z.object({
+	/** Repository in owner/name format */
+	repo: z.string().min(1),
+	/** ISO date when added */
+	added: z.string(),
+	/** How this repo was added */
+	source: z.enum(["manual", "discovered"]),
+	/** Topic tags */
+	tags: z.array(z.string()).default([]),
+	/** ISO date when last seen in a discovery run */
+	lastSeen: z.string().optional(),
+	/** Number of discovery runs that surfaced this repo */
+	discoveryCount: z.number().int().min(0).default(0),
+	/** Run ID that first discovered this repo */
+	runId: z.string().optional(),
+});
+
+/**
+ * Schema for a discovery log entry.
+ */
+export const DiscoveryLogEntrySchema = z.object({
+	/** Task ID of the run */
+	runId: z.string(),
+	/** ISO date of the run */
+	date: z.string(),
+	/** Number of repos auto-added */
+	reposAdded: z.number().int().min(0).default(0),
+	/** Number of existing repos with updated lastSeen */
+	reposUpdated: z.number().int().min(0).default(0),
+	/** Number of repos suggested for pruning */
+	pruningSuggested: z.number().int().min(0).default(0),
+});
+
+/**
+ * Schema for discovery thresholds.
+ */
+export const ThresholdsSchema = z.object({
+	/** Minimum stars to consider a repo */
+	minStars: z.number().int().min(0).default(50),
+	/** Stars threshold for auto-adding to watch list */
+	autoAddStars: z.number().int().min(0).default(500),
+	/** Maximum age in days for "new" repos */
+	maxAgeDays: z.number().int().min(1).default(30),
+});
+
+/**
+ * Schema for the watch manifest file.
+ */
+export const WatchManifestSchema = z.object({
+	/** Manifest version */
+	version: z.string().default("1.0"),
+	/** Topics of interest for discovery */
+	topics: z.array(z.string()).min(1, "At least one topic is required"),
+	/** Programming languages to prioritize */
+	languages: z.array(z.string()).default([]),
+	/** Currently watched repositories */
+	watch: z.array(WatchEntrySchema).default([]),
+	/** Scoring and auto-add thresholds */
+	thresholds: ThresholdsSchema.default(() => ({
+		minStars: 50,
+		autoAddStars: 500,
+		maxAgeDays: 30,
+	})),
+	/** Append-only log of discovery runs (capped at 50) */
+	discoveryLog: z.array(DiscoveryLogEntrySchema).default([]),
+});
+
+export type WatchManifest = z.infer<typeof WatchManifestSchema>;
+export type WatchEntry = z.infer<typeof WatchEntrySchema>;
+export type DiscoveryLogEntry = z.infer<typeof DiscoveryLogEntrySchema>;

--- a/src/schemas/results.ts
+++ b/src/schemas/results.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Results schemas for project-watcher.
+ * Defines the structure of discovery.json and status.json.
+ * @module schemas/results
+ */
+import { z } from "zod";
+
+/**
+ * Schema for a discovered repository.
+ */
+export const DiscoveryEntrySchema = z.object({
+	/** Repository in owner/name format */
+	repo: z.string(),
+	/** GitHub URL */
+	url: z.string().url(),
+	/** Repository description */
+	description: z.string().default(""),
+	/** Star count at time of discovery */
+	stars: z.number().int().min(0).default(0),
+	/** Primary language */
+	language: z.string().default(""),
+	/** Topics/tags */
+	topics: z.array(z.string()).default([]),
+	/** Which search sources found this repo */
+	sources: z.array(z.string()).default([]),
+	/** Which iteration discovered this repo */
+	discoveredIteration: z.number().int().min(1).default(1),
+	/** Analysis depth: shallow, medium, deep */
+	depth: z.enum(["shallow", "medium", "deep"]).default("shallow"),
+	/** Agent's analysis or notes about the repo */
+	analysis: z.string().default(""),
+	/** Related repos discovered through this one */
+	adjacentTo: z.array(z.string()).default([]),
+	/** Why this repo is interesting */
+	reasoning: z.string().default(""),
+	/** Whether it was auto-added to the manifest */
+	autoAdded: z.boolean().default(false),
+});
+
+/**
+ * Schema for discovery run statistics.
+ */
+export const DiscoveryStatsSchema = z.object({
+	/** Total search results processed */
+	totalSearched: z.number().int().min(0).default(0),
+	/** Total unique repos discovered */
+	totalDiscovered: z.number().int().min(0).default(0),
+	/** Repos auto-added to manifest */
+	autoAdded: z.number().int().min(0).default(0),
+	/** MCP sources used */
+	sourcesUsed: z.array(z.string()).default([]),
+});
+
+/**
+ * Schema for the discovery results file.
+ */
+export const DiscoveryResultsSchema = z.object({
+	/** Task ID for this run */
+	taskId: z.string(),
+	/** Number of iterations completed */
+	iterationsCompleted: z.number().int().min(0).default(0),
+	/** ISO timestamp */
+	timestamp: z.string().default(() => new Date().toISOString()),
+	/** Discovered repositories */
+	discoveries: z.array(DiscoveryEntrySchema).default([]),
+	/** Concepts and topics explored */
+	conceptsExplored: z.array(z.string()).default([]),
+	/** Research questions that were answered */
+	researchQuestionsAnswered: z.array(z.string()).default([]),
+	/** Run statistics */
+	stats: DiscoveryStatsSchema.default(() => ({
+		totalSearched: 0,
+		totalDiscovered: 0,
+		autoAdded: 0,
+		sourcesUsed: [],
+	})),
+});
+
+/**
+ * Schema for the run status file.
+ */
+export const WatchStatusSchema = z.object({
+	/** Task ID */
+	taskId: z.string(),
+	/** Run status */
+	status: z.enum(["running", "complete", "failed"]),
+	/** ISO timestamp when started */
+	startedAt: z.string(),
+	/** ISO timestamp when completed (if done) */
+	completedAt: z.string().nullable().default(null),
+	/** Current iteration */
+	currentIteration: z.number().int().min(0).default(0),
+	/** Max iterations configured */
+	maxIterations: z.number().int().min(0).default(10),
+	/** Repos discovered so far */
+	reposDiscovered: z.number().int().min(0).default(0),
+	/** Repos auto-added */
+	reposAdded: z.number().int().min(0).default(0),
+	/** Error message if failed */
+	error: z.string().nullable().default(null),
+});
+
+export type DiscoveryEntry = z.infer<typeof DiscoveryEntrySchema>;
+export type DiscoveryResults = z.infer<typeof DiscoveryResultsSchema>;
+export type WatchStatus = z.infer<typeof WatchStatusSchema>;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -32,3 +32,15 @@ export const DEFAULT_AGENT_NAME = "ralph-wiggum";
 
 /** Path to the default Ralph agent configuration */
 export const AGENT_CONFIG_PATH = join(KIRO_AGENTS_DIR, "ralph-wiggum.json");
+
+/** Directory for kiro settings (MCP config, etc.) */
+export const KIRO_SETTINGS_DIR = join(KIRO_DIR, "settings");
+
+/** Path to the watch manifest file */
+export const WATCH_MANIFEST_FILE = "watch-manifest.json";
+
+/** Default agent name for watch runs */
+export const WATCH_AGENT_NAME = "project-watcher";
+
+/** Directory for watch run results */
+export const RESULTS_DIR = "results";

--- a/watch-manifest.example.json
+++ b/watch-manifest.example.json
@@ -1,0 +1,19 @@
+{
+	"version": "1.0",
+	"topics": ["ai-agents", "mcp", "llm-tooling", "developer-tools"],
+	"languages": ["python", "typescript", "rust"],
+	"watch": [
+		{
+			"repo": "anthropics/claude-code",
+			"added": "2026-03-18",
+			"source": "manual",
+			"tags": ["ai-agents", "claude"]
+		}
+	],
+	"thresholds": {
+		"minStars": 50,
+		"autoAddStars": 500,
+		"maxAgeDays": 30
+	},
+	"discoveryLog": []
+}


### PR DESCRIPTION
## Summary

Adds a `ralph watch` command that discovers trending GitHub repositories through iterative deep research using Kiro CLI with existing MCP search servers (exa, brave-search, tavily).

- **`ralph watch`** — fire-and-forget discovery run using ralph's iterative loop (min 3, max 10 iterations)
- **`ralph watch init`** — scaffolds Kiro agent, steering file, MCP config, and watch manifest
- **`ralph watch results [id]`** — display results by task ID (or most recent)
- **`ralph watch ls`** — list recent watch runs with status

### How it works

Each run goes through iterative deepening:
1. **Iterations 1-3**: Broad discovery across exa/brave/tavily — find candidate repos, generate research questions
2. **Iterations 4-7**: Deep dive — analyze top repos, follow the graph (author's work, competitors), surface adjacent concepts
3. **Iterations 8-10**: Synthesis — compare approaches, write final summary, signal completion

Ralph's feedback XML (`nextSteps`, `ideas`, `blockers`) carries forward between iterations as the memory bridge.

### Manifest lifecycle

The watch manifest (`watch-manifest.json`) evolves over time:
- **Growth**: Agent auto-adds repos above `autoAddStars` threshold with full provenance (`lastSeen`, `discoveryCount`, `runId`)
- **Freshness**: `lastSeen` gets updated for existing repos encountered in searches
- **Pruning**: Agent *suggests* removing stale discovered repos (>90 days), never auto-removes. Manual entries are sacred.
- **Audit trail**: `discoveryLog` array tracks what each run did (capped at 50)

### Bug fix

`runLoop()` now returns a `LoopResult` object instead of calling `process.exit(0)` directly. This allows callers (watch-runner, loop command, resume command) to perform cleanup after the loop ends.

### Docs

- 4 ADRs: watch architecture, iterative deepening, MCP reuse, manifest lifecycle
- OpenSpec spec with 11 requirements (REQ-1 through REQ-11)
- OpenSpec initialized with Claude Code + Kiro support

### First run results

Tested with `ralph watch --min-iterations 1 --max-iterations 3` watching `strands-agents/sdk-python`:
- 21 repos discovered across 12 concepts
- Top finds: `karpathy/autoresearch` (39.8K★), `google-a2a/A2A` (22.6K★), `aden-hive/hive` (9.5K★)
- 7 emerging patterns identified (agent orchestration dashboards, MCP+A2A protocol stack, K8s agent runtimes, etc.)

## Test plan

- [x] `bunx tsc --noEmit` — typecheck clean
- [x] `bunx biome check src` — lint clean
- [x] `bun test` — 76 tests pass (0 regressions)
- [x] `ralph watch init` — scaffolds all 4 config files correctly
- [x] `ralph watch --help` — shows correct subcommands and options
- [x] Live run with kiro-cli against real MCP servers — produces discovery.json, iteration snapshots, summary.md