### PR TITLE
feat(scouts): isolated scout fleet with hooks, intra-scout subagents, knowledge index, and fleet ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -642,3 +642,6 @@ watch-manifest.json
 .kiro/settings/mcp.json
 .kiro/ralph-loop.local.json
 .kiro/ralph-session.json
+
+# Compiled single-file binary (105MB) from `bun build --compile`
+/ralph-for-kiro

--- a/.kiro/agents/project-watcher.json
+++ b/.kiro/agents/project-watcher.json
@@ -1,20 +1,20 @@
 {
-  "name": "project-watcher",
-  "description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
-  "tools": [
-    "read",
-    "write",
-    "@brave-search",
-    "@tavily",
-    "@exa"
-  ],
-  "allowedTools": [
-    "*"
-  ],
-  "includeMcpJson": true,
-  "resources": [
-    "file://../../watch-manifest.json",
-    "file://../ralph-loop.local.json"
-  ],
-  "prompt": "file://../steering/watcher-context.md"
+	"name": "project-watcher",
+	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
+	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
+	"allowedTools": ["*"],
+	"includeMcpJson": true,
+	"resources": [
+		"file://../../watch-manifest.json",
+		"file://../ralph-loop.local.json"
+	],
+	"prompt": "file://../steering/watcher-context.md",
+	"hooks": {
+		"agentSpawn": [
+			{ "command": ".kiro/hooks/on-agent-spawn.sh" }
+		],
+		"stop": [
+			{ "command": ".kiro/hooks/on-stop.sh" }
+		]
+	}
 }

--- a/.kiro/agents/project-watcher.json
+++ b/.kiro/agents/project-watcher.json
@@ -1,6 +1,6 @@
 {
 	"name": "project-watcher",
-	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
+	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages. Fans out per-topic deep dives to the probe-topic subagent.",
 	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
 	"allowedTools": ["*"],
 	"includeMcpJson": true,
@@ -9,6 +9,8 @@
 		"file://../ralph-loop.local.json"
 	],
 	"prompt": "file://../steering/watcher-context.md",
+	"availableAgents": ["probe-*"],
+	"trustedAgents": ["probe-topic"],
 	"hooks": {
 		"agentSpawn": [
 			{ "command": ".kiro/hooks/on-agent-spawn.sh" }

--- a/.kiro/hooks/on-agent-spawn.sh
+++ b/.kiro/hooks/on-agent-spawn.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Kiro `agentSpawn` hook — fired by kiro-cli when the agent starts a new turn.
+#
+# ralph-for-kiro sets these env vars on the subprocess before invoking kiro-cli
+# chat, so hooks always know where to write artifacts without parsing the
+# hook's JSON stdin payload:
+#
+#   RALPH_RUN_DIR       Absolute path to this run's `results/<scout>/pw-*/`
+#                       directory. Always exists.
+#   RALPH_ITERATION     1-based iteration number for this kiro-cli invocation.
+#   RALPH_SCOUT_NAME    Scout name (empty for non-scout watch runs).
+#
+# The hook writes an iteration-marker JSON so the runner never has to grep
+# stdout or re-read Kiro's SQLite DB to know a turn started.
+
+set -euo pipefail
+
+RUN_DIR="${RALPH_RUN_DIR:-}"
+ITERATION="${RALPH_ITERATION:-0}"
+
+if [[ -z "${RUN_DIR}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${RUN_DIR}/iterations"
+
+# Pad to 2 digits so `ls iterations/` sorts chronologically.
+ITER_PADDED="$(printf '%02d' "${ITERATION}")"
+MARKER="${RUN_DIR}/iterations/${ITER_PADDED}-spawn.json"
+
+cat > "${MARKER}" <<JSON
+{
+  "iteration": ${ITERATION},
+  "spawnedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "scout": "${RALPH_SCOUT_NAME:-}",
+  "cwd": "$(pwd)"
+}
+JSON

--- a/.kiro/hooks/on-stop.sh
+++ b/.kiro/hooks/on-stop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Kiro `stop` hook — fired when the agent signals the turn is complete.
+#
+# See on-agent-spawn.sh for the RALPH_* env-var contract. This hook writes a
+# per-turn `NN-turn.json` sidecar with a simple "turn ended" marker the loop
+# runner can watch for. Kiro versions vary in what they pipe on stdin for this
+# hook; we intentionally do not parse it — the env vars are enough.
+
+set -euo pipefail
+
+RUN_DIR="${RALPH_RUN_DIR:-}"
+ITERATION="${RALPH_ITERATION:-0}"
+
+if [[ -z "${RUN_DIR}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${RUN_DIR}/iterations"
+
+ITER_PADDED="$(printf '%02d' "${ITERATION}")"
+MARKER="${RUN_DIR}/iterations/${ITER_PADDED}-turn.json"
+
+cat > "${MARKER}" <<JSON
+{
+  "iteration": ${ITERATION},
+  "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "scout": "${RALPH_SCOUT_NAME:-}"
+}
+JSON

--- a/.kiro/steering/watcher-context.md
+++ b/.kiro/steering/watcher-context.md
@@ -150,9 +150,54 @@ Trends and patterns observed across discoveries.
 ## Recommended for Watch List
 Repos that meet auto-add thresholds.
 
+## Pruning Suggestions
+Repos with `source: "discovered"` where `lastSeen` > 90 days ago.
+
 ## Open Questions
 Leads for future discovery runs.
 ```
+
+## Manifest Lifecycle — IMPORTANT
+
+You are responsible for keeping `watch-manifest.json` up to date. On your FINAL iteration:
+
+### Auto-Add (Growth)
+When you discover a repo that exceeds the `autoAddStars` threshold AND is not already in the `watch` array:
+- Add it to the `watch` array with these fields:
+  - `repo`: owner/name
+  - `added`: today's date (YYYY-MM-DD)
+  - `source`: "discovered"
+  - `tags`: relevant topic tags from the manifest
+  - `lastSeen`: today's date
+  - `discoveryCount`: 1
+  - `runId`: the task ID from your prompt
+
+### Freshness Tracking
+For every repo already in the `watch` array that you encounter in search results:
+- Update `lastSeen` to today's date
+- Increment `discoveryCount` by 1
+
+### Pruning Suggestions
+For repos where `source` is `"discovered"` and `lastSeen` is more than 90 days ago:
+- Do NOT remove them
+- List them in the "Pruning Suggestions" section of `summary.md` with reasoning
+- Manual entries (`source: "manual"`) are NEVER flagged
+
+### Discovery Log
+Append an entry to the `discoveryLog` array in the manifest:
+```json
+{
+  "runId": "TASK_ID",
+  "date": "YYYY-MM-DD",
+  "reposAdded": N,
+  "reposUpdated": N,
+  "pruningSuggested": N
+}
+```
+Cap the `discoveryLog` at 50 entries (remove oldest if needed).
+
+### Writing the Manifest
+After making changes, write the updated `watch-manifest.json` back to the project root. Preserve existing manual entries exactly as they are.
 
 ## Completion Rules
 

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"complexity": {
+				"useLiteralKeys": "off"
+			}
 		}
 	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } }

--- a/scouts/agent-sdks/manifest.json
+++ b/scouts/agent-sdks/manifest.json
@@ -1,0 +1,12 @@
+{
+	"version": "1.0",
+	"topics": ["ai-agents", "mcp", "llm-tooling", "developer-tools", "strands-agents"],
+	"languages": ["python", "typescript", "rust"],
+	"watch": [],
+	"thresholds": {
+		"minStars": 50,
+		"autoAddStars": 500,
+		"maxAgeDays": 30
+	},
+	"discoveryLog": []
+}

--- a/scouts/ai-eval/manifest.json
+++ b/scouts/ai-eval/manifest.json
@@ -1,0 +1,37 @@
+{
+	"version": "1.0",
+	"topics": ["ai-evaluation", "llm-benchmarks", "agent-testing", "prompt-testing", "red-teaming", "rag-evaluation"],
+	"languages": ["python", "typescript"],
+	"watch": [
+		{
+			"repo": "confident-ai/deepeval",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["ai-evaluation", "llm-benchmarks", "pytest"]
+		},
+		{
+			"repo": "explodinggradients/ragas",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["rag-evaluation", "ai-evaluation"]
+		},
+		{
+			"repo": "promptfoo/promptfoo",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["prompt-testing", "red-teaming", "ai-evaluation"]
+		},
+		{
+			"repo": "braintrustdata/braintrust-sdk",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["ai-evaluation", "llm-benchmarks"]
+		}
+	],
+	"thresholds": {
+		"minStars": 50,
+		"autoAddStars": 300,
+		"maxAgeDays": 60
+	},
+	"discoveryLog": []
+}

--- a/scouts/ai-security/manifest.json
+++ b/scouts/ai-security/manifest.json
@@ -1,0 +1,31 @@
+{
+	"version": "1.0",
+	"topics": ["ai-safety", "prompt-injection", "llm-guardrails", "ai-red-teaming", "agent-security", "ai-alignment"],
+	"languages": ["python", "typescript", "rust"],
+	"watch": [
+		{
+			"repo": "NVIDIA/NeMo-Guardrails",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["llm-guardrails", "ai-safety"]
+		},
+		{
+			"repo": "guardrails-ai/guardrails",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["llm-guardrails", "ai-safety"]
+		},
+		{
+			"repo": "rebuff-ai/rebuff",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["prompt-injection", "ai-safety"]
+		}
+	],
+	"thresholds": {
+		"minStars": 30,
+		"autoAddStars": 200,
+		"maxAgeDays": 60
+	},
+	"discoveryLog": []
+}

--- a/scouts/computer-use/manifest.json
+++ b/scouts/computer-use/manifest.json
@@ -1,0 +1,31 @@
+{
+	"version": "1.0",
+	"topics": ["browser-automation", "computer-use", "desktop-agents", "gui-grounding", "web-agents", "screen-understanding"],
+	"languages": ["python", "typescript", "rust"],
+	"watch": [
+		{
+			"repo": "anthropics/anthropic-quickstarts",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["computer-use", "desktop-agents"]
+		},
+		{
+			"repo": "browser-use/browser-use",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["browser-automation", "web-agents"]
+		},
+		{
+			"repo": "anthropics/claude-computer-use-demo",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["computer-use", "desktop-agents"]
+		}
+	],
+	"thresholds": {
+		"minStars": 50,
+		"autoAddStars": 500,
+		"maxAgeDays": 45
+	},
+	"discoveryLog": []
+}

--- a/scouts/inference-infra/manifest.json
+++ b/scouts/inference-infra/manifest.json
@@ -1,0 +1,37 @@
+{
+	"version": "1.0",
+	"topics": ["llm-serving", "inference-optimization", "model-quantization", "local-llm", "edge-inference", "speculative-decoding"],
+	"languages": ["python", "rust", "cpp"],
+	"watch": [
+		{
+			"repo": "vllm-project/vllm",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["llm-serving", "inference-optimization"]
+		},
+		{
+			"repo": "ggml-org/llama.cpp",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["local-llm", "model-quantization", "inference-optimization"]
+		},
+		{
+			"repo": "sgl-project/sglang",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["llm-serving", "inference-optimization"]
+		},
+		{
+			"repo": "mlc-ai/mlc-llm",
+			"added": "2026-03-23",
+			"source": "manual",
+			"tags": ["edge-inference", "local-llm"]
+		}
+	],
+	"thresholds": {
+		"minStars": 100,
+		"autoAddStars": 1000,
+		"maxAgeDays": 30
+	},
+	"discoveryLog": []
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,8 @@ export {
 	scoutLsCommand,
 	scoutResultsCommand,
 	scoutRunCommand,
+	scoutStatusCommand,
+	scoutTailCommand,
 } from "./scout";
 export {
 	watchInitCommand,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,12 @@ export { initCommand } from "./init";
 export { loopCommand } from "./loop";
 export { resumeCommand } from "./resume";
 export {
+	scoutInitCommand,
+	scoutLsCommand,
+	scoutResultsCommand,
+	scoutRunCommand,
+} from "./scout";
+export {
 	watchInitCommand,
 	watchLsCommand,
 	watchResultsCommand,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,6 +7,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import pc from "picocolors";
+import { installHookScripts } from "../core/hook-installer";
 import steeringContent from "../data/ralph-context.md" with { type: "text" };
 // Import bundled data files
 import agentConfig from "../data/ralph-wiggum.json";
@@ -54,6 +55,12 @@ export async function initCommand(opts: InitOptions): Promise<void> {
 	// Write steering file (imported as text at compile time)
 	await Bun.write(steeringPath, steeringContent);
 	log.success(`${pc.green("Created")} ${steeringPath}`);
+
+	// Stamp lifecycle hook scripts alongside the agent.
+	const hookPaths = await installHookScripts();
+	for (const p of hookPaths) {
+		log.success(`${pc.green("Created")} ${p}`);
+	}
 
 	// Success message
 	console.log();

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -1,0 +1,325 @@
+/**
+ * @fileoverview Scout command for Ralph Wiggum CLI.
+ * Manages a fleet of focused discovery scouts, each with its own manifest.
+ * @module commands/scout
+ */
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "@clack/prompts";
+import pc from "picocolors";
+import {
+	listRuns,
+	readManifest,
+	runWatch,
+	type WatchRunEntry,
+} from "../core/watch-runner";
+import { SCOUTS_DIR } from "../utils/paths";
+
+/**
+ * A scout definition derived from its directory and manifest.
+ */
+interface ScoutInfo {
+	/** Scout name (directory name) */
+	name: string;
+	/** Path to the scout's manifest file */
+	manifestPath: string;
+	/** Topics from the manifest */
+	topics: string[];
+	/** Languages from the manifest */
+	languages: string[];
+	/** Number of watched repos */
+	watchCount: number;
+}
+
+/**
+ * CLI options for the scout run command.
+ */
+interface ScoutRunOptions {
+	name?: string;
+	minIterations: string;
+	maxIterations: string;
+	agent?: string;
+}
+
+/**
+ * Discovers all scouts in the scouts/ directory.
+ * Each subdirectory with a manifest.json is a scout.
+ */
+async function discoverScouts(): Promise<ScoutInfo[]> {
+	try {
+		await readdir(SCOUTS_DIR);
+	} catch {
+		return [];
+	}
+
+	const entries = await readdir(SCOUTS_DIR, { withFileTypes: true });
+	const scouts: ScoutInfo[] = [];
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+
+		const manifestPath = join(SCOUTS_DIR, entry.name, "manifest.json");
+		try {
+			const manifest = await readManifest(manifestPath);
+			scouts.push({
+				name: entry.name,
+				manifestPath,
+				topics: manifest.topics,
+				languages: manifest.languages,
+				watchCount: manifest.watch.length,
+			});
+		} catch {
+			// Skip directories without valid manifests
+		}
+	}
+
+	return scouts.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Runs one or all scouts sequentially.
+ */
+export async function scoutRunCommand(opts: ScoutRunOptions): Promise<void> {
+	const minIterations = Number.parseInt(opts.minIterations, 10);
+	const maxIterations = Number.parseInt(opts.maxIterations, 10);
+
+	if (Number.isNaN(minIterations) || minIterations < 1) {
+		log.error(pc.red("Invalid --min-iterations value"));
+		process.exit(1);
+	}
+	if (Number.isNaN(maxIterations) || maxIterations < 1) {
+		log.error(pc.red("Invalid --max-iterations value"));
+		process.exit(1);
+	}
+
+	const allScouts = await discoverScouts();
+
+	if (allScouts.length === 0) {
+		log.error(
+			pc.red(
+				`No scouts found in ${SCOUTS_DIR}/\nRun 'ralph scout init <name>' to create one.`,
+			),
+		);
+		return;
+	}
+
+	// Filter to a specific scout if --name is given
+	const scouts = opts.name
+		? allScouts.filter((s) => s.name === opts.name)
+		: allScouts;
+
+	if (opts.name && scouts.length === 0) {
+		log.error(
+			pc.red(
+				`Scout "${opts.name}" not found. Available: ${allScouts.map((s) => s.name).join(", ")}`,
+			),
+		);
+		return;
+	}
+
+	log.info(pc.bold(pc.blue(`Deploying ${scouts.length} scout(s)`)));
+	console.log();
+
+	const results: { name: string; ok: boolean; error?: string }[] = [];
+
+	for (const scout of scouts) {
+		log.info(pc.bold(`Scout [${pc.cyan(scout.name)}]`));
+		log.message(pc.dim(`   Topics: ${scout.topics.join(", ")}`));
+		log.message(pc.dim(`   Watching: ${scout.watchCount} repos`));
+		console.log();
+
+		try {
+			await runWatch({
+				minIterations,
+				maxIterations,
+				agentName: opts.agent ?? null,
+				manifestPath: scout.manifestPath,
+				scoutName: scout.name,
+			});
+			results.push({ name: scout.name, ok: true });
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			log.error(pc.red(`Scout [${scout.name}] failed: ${msg}`));
+			results.push({ name: scout.name, ok: false, error: msg });
+		}
+
+		console.log();
+	}
+
+	// Summary
+	const succeeded = results.filter((r) => r.ok).length;
+	const failed = results.filter((r) => !r.ok).length;
+
+	log.info(pc.bold("Fleet Summary"));
+	log.message(
+		`   ${pc.green(`${succeeded} succeeded`)}${failed > 0 ? `, ${pc.red(`${failed} failed`)}` : ""}`,
+	);
+}
+
+/**
+ * Lists all available scouts and their configuration.
+ */
+export async function scoutLsCommand(): Promise<void> {
+	const scouts = await discoverScouts();
+
+	if (scouts.length === 0) {
+		log.message(
+			`No scouts found in ${SCOUTS_DIR}/. Run 'ralph scout init <name>' to create one.`,
+		);
+		return;
+	}
+
+	log.info(pc.bold(`${scouts.length} scout(s):`));
+	console.log();
+
+	for (const scout of scouts) {
+		log.message(
+			`  ${pc.bold(pc.cyan(scout.name))}  ${scout.topics.join(", ")}  (${scout.watchCount} repos)`,
+		);
+		log.message(pc.dim(`    ${scout.manifestPath}`));
+	}
+}
+
+/**
+ * Shows results for a specific scout.
+ */
+export async function scoutResultsCommand(name?: string): Promise<void> {
+	if (!name) {
+		// Show latest run across all scouts
+		const scouts = await discoverScouts();
+		if (scouts.length === 0) {
+			log.message("No scouts found.");
+			return;
+		}
+
+		const allRuns: WatchRunEntry[] = [];
+		for (const scout of scouts) {
+			const runs = await listRuns(scout.name);
+			allRuns.push(...runs);
+		}
+
+		if (allRuns.length === 0) {
+			log.message("No runs found across any scouts.");
+			return;
+		}
+
+		// Sort all runs by start time
+		allRuns.sort(
+			(a, b) =>
+				new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+		);
+
+		log.info(pc.bold("Recent runs across all scouts:"));
+		console.log();
+
+		for (const run of allRuns.slice(0, 10)) {
+			const statusColor =
+				run.status === "complete"
+					? pc.green
+					: run.status === "failed"
+						? pc.red
+						: pc.yellow;
+			const scoutLabel = run.scoutName ? pc.cyan(`[${run.scoutName}]`) : "";
+
+			const date = new Date(run.startedAt).toLocaleDateString("en-US", {
+				month: "short",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+
+			log.message(
+				`  ${scoutLabel} ${pc.bold(run.taskId)}  ${statusColor(run.status.padEnd(8))}  ${date}`,
+			);
+		}
+		return;
+	}
+
+	// Show runs for a specific scout
+	const runs = await listRuns(name);
+	if (runs.length === 0) {
+		log.message(`No runs found for scout "${name}".`);
+		return;
+	}
+
+	log.info(pc.bold(`Runs for scout [${pc.cyan(name)}]:`));
+	console.log();
+
+	for (const run of runs) {
+		const statusColor =
+			run.status === "complete"
+				? pc.green
+				: run.status === "failed"
+					? pc.red
+					: pc.yellow;
+
+		const date = new Date(run.startedAt).toLocaleDateString("en-US", {
+			month: "short",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+
+		log.message(
+			`  ${pc.bold(run.taskId)}  ${statusColor(run.status.padEnd(8))}  ${date}  ${run.reposDiscovered} repos`,
+		);
+	}
+}
+
+/**
+ * Scaffolds a new scout with an empty manifest.
+ */
+export async function scoutInitCommand(
+	name: string,
+	opts: { topics?: string; languages?: string; force?: boolean },
+): Promise<void> {
+	const scoutDir = join(SCOUTS_DIR, name);
+	const manifestPath = join(scoutDir, "manifest.json");
+
+	// Check for existing
+	if (!opts.force) {
+		try {
+			if (await Bun.file(manifestPath).exists()) {
+				log.error(
+					pc.red(
+						`Scout "${name}" already exists at ${manifestPath}. Use --force to overwrite.`,
+					),
+				);
+				return;
+			}
+		} catch {
+			// Doesn't exist, good
+		}
+	}
+
+	await mkdir(scoutDir, { recursive: true });
+
+	const topics = opts.topics
+		? opts.topics.split(",").map((t) => t.trim())
+		: [name];
+	const languages = opts.languages
+		? opts.languages.split(",").map((l) => l.trim())
+		: ["python", "typescript", "rust"];
+
+	const manifest = {
+		version: "1.0",
+		topics,
+		languages,
+		watch: [],
+		thresholds: {
+			minStars: 50,
+			autoAddStars: 500,
+			maxAgeDays: 30,
+		},
+		discoveryLog: [],
+	};
+
+	await Bun.write(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
+
+	log.success(
+		`${pc.green("Created")} scout ${pc.cyan(name)} at ${manifestPath}`,
+	);
+	log.message(pc.dim(`  Topics: ${topics.join(", ")}`));
+	log.message(pc.dim(`  Languages: ${languages.join(", ")}`));
+	log.message(pc.dim(`\n  Run: ralph scout run --name ${name}`));
+}

--- a/src/commands/scout.ts
+++ b/src/commands/scout.ts
@@ -13,7 +13,7 @@ import {
 	runWatch,
 	type WatchRunEntry,
 } from "../core/watch-runner";
-import { SCOUTS_DIR } from "../utils/paths";
+import { RESULTS_DIR, SCOUTS_DIR } from "../utils/paths";
 
 /**
  * A scout definition derived from its directory and manifest.
@@ -39,6 +39,7 @@ interface ScoutRunOptions {
 	minIterations: string;
 	maxIterations: string;
 	agent?: string;
+	concurrency?: string;
 }
 
 /**
@@ -117,34 +118,25 @@ export async function scoutRunCommand(opts: ScoutRunOptions): Promise<void> {
 		return;
 	}
 
-	log.info(pc.bold(pc.blue(`Deploying ${scouts.length} scout(s)`)));
+	const concurrency = Math.max(
+		1,
+		Number.parseInt(opts.concurrency ?? "1", 10) || 1,
+	);
+
+	log.info(
+		pc.bold(
+			pc.blue(
+				`Deploying ${scouts.length} scout(s)${concurrency > 1 ? ` (concurrency=${concurrency})` : ""}`,
+			),
+		),
+	);
 	console.log();
 
-	const results: { name: string; ok: boolean; error?: string }[] = [];
-
-	for (const scout of scouts) {
-		log.info(pc.bold(`Scout [${pc.cyan(scout.name)}]`));
-		log.message(pc.dim(`   Topics: ${scout.topics.join(", ")}`));
-		log.message(pc.dim(`   Watching: ${scout.watchCount} repos`));
-		console.log();
-
-		try {
-			await runWatch({
-				minIterations,
-				maxIterations,
-				agentName: opts.agent ?? null,
-				manifestPath: scout.manifestPath,
-				scoutName: scout.name,
-			});
-			results.push({ name: scout.name, ok: true });
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
-			log.error(pc.red(`Scout [${scout.name}] failed: ${msg}`));
-			results.push({ name: scout.name, ok: false, error: msg });
-		}
-
-		console.log();
-	}
+	const results = await runScoutsWithConcurrency(scouts, concurrency, {
+		minIterations,
+		maxIterations,
+		agentName: opts.agent ?? null,
+	});
 
 	// Summary
 	const succeeded = results.filter((r) => r.ok).length;
@@ -154,6 +146,82 @@ export async function scoutRunCommand(opts: ScoutRunOptions): Promise<void> {
 	log.message(
 		`   ${pc.green(`${succeeded} succeeded`)}${failed > 0 ? `, ${pc.red(`${failed} failed`)}` : ""}`,
 	);
+	for (const r of results) {
+		if (!r.ok) {
+			log.message(
+				pc.dim(`   ${pc.red("✗")} ${r.name}: ${r.error ?? "unknown"}`),
+			);
+		}
+	}
+}
+
+interface ScoutRunContext {
+	minIterations: number;
+	maxIterations: number;
+	agentName: string | null;
+}
+
+interface ScoutRunResult {
+	name: string;
+	ok: boolean;
+	error?: string;
+}
+
+/**
+ * Drain a list of scouts into N parallel workers. Each worker pulls the next
+ * available scout off a shared queue and runs it to completion before pulling
+ * the next one. Errors are caught per-scout so one failure never aborts the
+ * fleet.
+ */
+async function runScoutsWithConcurrency(
+	scouts: ScoutInfo[],
+	concurrency: number,
+	ctx: ScoutRunContext,
+): Promise<ScoutRunResult[]> {
+	const queue = [...scouts];
+	const results: ScoutRunResult[] = [];
+	const workers: Promise<void>[] = [];
+	const workerCount = Math.min(concurrency, scouts.length);
+
+	for (let i = 0; i < workerCount; i++) {
+		workers.push(
+			(async () => {
+				while (queue.length > 0) {
+					const scout = queue.shift();
+					if (!scout) break;
+
+					log.info(pc.bold(`Scout [${pc.cyan(scout.name)}]`));
+					log.message(pc.dim(`   Topics: ${scout.topics.join(", ")}`));
+					log.message(pc.dim(`   Watching: ${scout.watchCount} repos`));
+
+					try {
+						await runWatch({
+							minIterations: ctx.minIterations,
+							maxIterations: ctx.maxIterations,
+							agentName: ctx.agentName,
+							manifestPath: scout.manifestPath,
+							scoutName: scout.name,
+						});
+						results.push({ name: scout.name, ok: true });
+					} catch (error) {
+						const msg = error instanceof Error ? error.message : String(error);
+						log.error(pc.red(`Scout [${scout.name}] failed: ${msg}`));
+						results.push({ name: scout.name, ok: false, error: msg });
+					}
+				}
+			})(),
+		);
+	}
+
+	await Promise.all(workers);
+
+	// Preserve deterministic order (match original scout list order).
+	const ordered: ScoutRunResult[] = [];
+	for (const s of scouts) {
+		const found = results.find((r) => r.name === s.name);
+		if (found) ordered.push(found);
+	}
+	return ordered;
 }
 
 /**
@@ -322,4 +390,145 @@ export async function scoutInitCommand(
 	log.message(pc.dim(`  Topics: ${topics.join(", ")}`));
 	log.message(pc.dim(`  Languages: ${languages.join(", ")}`));
 	log.message(pc.dim(`\n  Run: ralph scout run --name ${name}`));
+}
+
+/**
+ * Fleet-wide status — one line per scout with the latest run's
+ * task ID, status, duration, and repos-discovered count.
+ */
+export async function scoutStatusCommand(): Promise<void> {
+	const scouts = await discoverScouts();
+	if (scouts.length === 0) {
+		log.message(`No scouts found in ${SCOUTS_DIR}/.`);
+		return;
+	}
+
+	log.info(pc.bold("Scout fleet status"));
+	console.log();
+
+	for (const scout of scouts) {
+		const runs = await listRuns(scout.name);
+		if (runs.length === 0) {
+			log.message(
+				`  ${pc.bold(pc.cyan(scout.name.padEnd(18)))}  ${pc.dim("no runs yet")}`,
+			);
+			continue;
+		}
+
+		const latest = runs[0];
+		if (!latest) continue;
+
+		const statusColor =
+			latest.status === "complete"
+				? pc.green
+				: latest.status === "failed"
+					? pc.red
+					: pc.yellow;
+
+		const duration =
+			latest.completedAt && latest.startedAt
+				? Math.round(
+						(new Date(latest.completedAt).getTime() -
+							new Date(latest.startedAt).getTime()) /
+							1000,
+					)
+				: null;
+
+		const durationStr = duration !== null ? `${duration}s` : "—";
+		const iterations = `${latest.currentIteration}/${latest.maxIterations}`;
+
+		log.message(
+			`  ${pc.bold(pc.cyan(scout.name.padEnd(18)))}  ${statusColor(
+				latest.status.padEnd(8),
+			)}  ${pc.dim(latest.taskId)}  ${pc.dim(`iter ${iterations}`)}  ${pc.dim(durationStr)}  ${pc.dim(`${latest.reposDiscovered} repos`)}`,
+		);
+	}
+}
+
+/**
+ * Follow a scout's in-flight run, printing each new hook sidecar
+ * (`NN-spawn.json` and `NN-turn.json` from `.kiro/hooks/*.sh`) as it
+ * lands in the latest run's `iterations/` directory. Polls every 2s.
+ */
+export async function scoutTailCommand(
+	name: string,
+	opts: { interval?: string } = {},
+): Promise<void> {
+	const intervalMs = Math.max(
+		250,
+		Number.parseInt(opts.interval ?? "2000", 10) || 2000,
+	);
+
+	const scouts = await discoverScouts();
+	const scout = scouts.find((s) => s.name === name);
+	if (!scout) {
+		log.error(
+			pc.red(
+				`Scout "${name}" not found. Available: ${scouts.map((s) => s.name).join(", ")}`,
+			),
+		);
+		return;
+	}
+
+	const runs = await listRuns(name);
+	const latest = runs[0];
+	if (!latest) {
+		log.message(`No runs yet for scout "${name}".`);
+		return;
+	}
+
+	const iterationsDir = join(RESULTS_DIR, name, latest.taskId, "iterations");
+	log.info(pc.bold(`Tailing ${pc.cyan(name)} — run ${latest.taskId}`));
+	log.message(pc.dim(`   ${iterationsDir} (polling every ${intervalMs}ms)`));
+	console.log();
+
+	const seen = new Set<string>();
+
+	// Initial snapshot — print already-present sidecars, then stream.
+	const initial = await safeReaddir(iterationsDir);
+	for (const f of initial.sort()) {
+		if (f.endsWith(".json")) {
+			seen.add(f);
+			log.message(pc.dim(`  [catch-up] ${f}`));
+		}
+	}
+
+	// Poll until the run finishes. Non-blocking on Ctrl+C — SIGINT kicks us
+	// out cleanly.
+	let shouldStop = false;
+	process.on("SIGINT", () => {
+		shouldStop = true;
+	});
+
+	while (!shouldStop) {
+		await new Promise((resolve) => setTimeout(resolve, intervalMs));
+		const entries = await safeReaddir(iterationsDir);
+		for (const f of entries.sort()) {
+			if (!f.endsWith(".json") || seen.has(f)) continue;
+			seen.add(f);
+			log.message(
+				`  ${pc.green("▸")} ${pc.bold(f)}  ${pc.dim(new Date().toISOString())}`,
+			);
+		}
+
+		// Stop tailing once the run has left `running` state.
+		const refreshed = await listRuns(name);
+		const current = refreshed[0];
+		if (
+			current &&
+			current.taskId === latest.taskId &&
+			current.status !== "running"
+		) {
+			log.message(pc.dim(`\n  Run ${current.status} — stopped tailing.`));
+			break;
+		}
+	}
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+	try {
+		return await readdir(dir);
+	} catch {
+		return [];
+	}
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,6 +7,7 @@ import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "@clack/prompts";
 import pc from "picocolors";
+import { installHookScripts } from "../core/hook-installer";
 import {
 	listRuns,
 	readStatus,
@@ -106,6 +107,12 @@ export async function watchInitCommand(opts: WatchInitOptions): Promise<void> {
 	// Write steering file
 	await Bun.write(steeringPath, steeringContent);
 	log.success(`${pc.green("Created")} ${steeringPath}`);
+
+	// Stamp lifecycle hook scripts alongside the agent.
+	const hookPaths = await installHookScripts();
+	for (const p of hookPaths) {
+		log.success(`${pc.green("Created")} ${p}`);
+	}
 
 	// Copy MCP config if it doesn't exist
 	if (!(await Bun.file(mcpTargetPath).exists())) {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -30,6 +30,8 @@ interface WatchRunOptions {
 	minIterations: string;
 	maxIterations: string;
 	agent?: string;
+	manifest?: string;
+	scout?: string;
 }
 
 /**
@@ -60,6 +62,8 @@ export async function watchRunCommand(opts: WatchRunOptions): Promise<void> {
 		minIterations,
 		maxIterations,
 		agentName: opts.agent ?? null,
+		manifestPath: opts.manifest ?? null,
+		scoutName: opts.scout ?? null,
 	});
 }
 

--- a/src/core/hook-installer.ts
+++ b/src/core/hook-installer.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Shared utility for installing the Kiro lifecycle hook scripts
+ * that write per-turn sidecar artifacts under a run's `iterations/` dir.
+ *
+ * Both `ralph init` and `ralph watch init` call this so every surface that
+ * scaffolds a Kiro agent also drops the hooks next to it.
+ *
+ * @module core/hook-installer
+ */
+import { chmod, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import onAgentSpawnScript from "../data/hooks/on-agent-spawn.sh" with {
+	type: "text",
+};
+import onStopScript from "../data/hooks/on-stop.sh" with { type: "text" };
+import { KIRO_HOOKS_DIR } from "../utils/paths";
+
+/** Hook file names, mirrored by agent JSON's `hooks` field. */
+export const HOOK_FILES = {
+	onAgentSpawn: "on-agent-spawn.sh",
+	onStop: "on-stop.sh",
+} as const;
+
+/**
+ * Write the agentSpawn + stop hook scripts under `.kiro/hooks/`, chmod'd
+ * executable. Idempotent: overwrites existing files so bumps to the script
+ * body propagate on `ralph init --force` or subsequent `watch init`.
+ *
+ * @returns Absolute paths to the written scripts.
+ */
+export async function installHookScripts(
+	hooksDir: string = KIRO_HOOKS_DIR,
+): Promise<string[]> {
+	await mkdir(hooksDir, { recursive: true });
+
+	const written: string[] = [];
+	const scripts: Array<[string, string]> = [
+		[HOOK_FILES.onAgentSpawn, onAgentSpawnScript],
+		[HOOK_FILES.onStop, onStopScript],
+	];
+
+	for (const [name, body] of scripts) {
+		const path = join(hooksDir, name);
+		await Bun.write(path, body);
+		await chmod(path, 0o755);
+		written.push(path);
+	}
+
+	return written;
+}

--- a/src/core/kiro-client.ts
+++ b/src/core/kiro-client.ts
@@ -20,6 +20,19 @@ export interface HookEnv {
 	scoutName?: string;
 }
 
+/** Optional overrides passed per `runChat` invocation. */
+export interface RunChatOptions {
+	/** Hook env vars made available to `.kiro/hooks/*.sh` scripts. */
+	hookEnv?: HookEnv;
+	/**
+	 * Working directory for the spawned kiro-cli subprocess. When set, Kiro
+	 * discovers a sibling `.kiro/` tree here (agents, steering, hooks, MCP
+	 * config, SQLite session history) which is how scout isolation works —
+	 * each scout runs with its own cwd and therefore its own `.kiro/`.
+	 */
+	cwd?: string;
+}
+
 /**
  * Client for interacting with kiro-cli subprocess.
  * Wraps the kiro-cli chat command with the Ralph Wiggum agent.
@@ -55,11 +68,11 @@ export class KiroClient {
 	/**
 	 * Run a kiro-cli chat session.
 	 * @param prompt - The prompt to send to kiro-cli
-	 * @param hookEnv - Optional hook environment (runDir, iteration, scoutName).
+	 * @param options - Optional per-invocation overrides (hook env, cwd).
 	 * @returns Exit code from kiro-cli
 	 */
-	async runChat(prompt: string, hookEnv?: HookEnv): Promise<number> {
-		const env = buildHookEnv(hookEnv);
+	async runChat(prompt: string, options?: RunChatOptions): Promise<number> {
+		const env = buildHookEnv(options?.hookEnv);
 
 		// Pass prompt as positional argument [INPUT], not via stdin
 		const proc = Bun.spawn(
@@ -76,6 +89,7 @@ export class KiroClient {
 				stdout: "inherit", // Show output in real-time
 				stderr: "inherit",
 				env,
+				...(options?.cwd ? { cwd: options.cwd } : {}),
 			},
 		);
 
@@ -92,6 +106,9 @@ export function buildHookEnv(hookEnv?: HookEnv): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = { ...process.env };
 	if (!hookEnv) return env;
 
+	// Bracket access required: NodeJS.ProcessEnv is an index-signature type
+	// under TS strict (`noPropertyAccessFromIndexSignature`). Biome's
+	// `useLiteralKeys` is disabled in biome.json to avoid the rule conflict.
 	if (hookEnv.runDir !== undefined) {
 		env["RALPH_RUN_DIR"] = hookEnv.runDir;
 	}

--- a/src/core/kiro-client.ts
+++ b/src/core/kiro-client.ts
@@ -6,6 +6,21 @@
 import { AGENT_CONFIG_PATH, DEFAULT_AGENT_NAME } from "../utils/paths";
 
 /**
+ * Per-invocation hook environment passed to kiro-cli. These env vars let the
+ * scripts in `.kiro/hooks/` emit structured per-turn artifacts (spawn marker,
+ * stop marker) into a known run directory without having to parse the hook's
+ * JSON stdin payload, which varies across Kiro versions.
+ */
+export interface HookEnv {
+	/** Absolute path to the run's results dir (e.g. `results/<scout>/pw-*`). */
+	runDir?: string;
+	/** 1-based iteration number the runner is about to execute. */
+	iteration?: number;
+	/** Scout name, if this is a scout-scoped run. Empty string otherwise. */
+	scoutName?: string;
+}
+
+/**
  * Client for interacting with kiro-cli subprocess.
  * Wraps the kiro-cli chat command with the Ralph Wiggum agent.
  */
@@ -40,9 +55,12 @@ export class KiroClient {
 	/**
 	 * Run a kiro-cli chat session.
 	 * @param prompt - The prompt to send to kiro-cli
+	 * @param hookEnv - Optional hook environment (runDir, iteration, scoutName).
 	 * @returns Exit code from kiro-cli
 	 */
-	async runChat(prompt: string): Promise<number> {
+	async runChat(prompt: string, hookEnv?: HookEnv): Promise<number> {
+		const env = buildHookEnv(hookEnv);
+
 		// Pass prompt as positional argument [INPUT], not via stdin
 		const proc = Bun.spawn(
 			[
@@ -57,10 +75,31 @@ export class KiroClient {
 			{
 				stdout: "inherit", // Show output in real-time
 				stderr: "inherit",
+				env,
 			},
 		);
 
 		await proc.exited;
 		return proc.exitCode ?? 1;
 	}
+}
+
+/**
+ * Build the child-process env by layering RALPH_* hook vars onto the parent
+ * process env. Exported for testing.
+ */
+export function buildHookEnv(hookEnv?: HookEnv): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env };
+	if (!hookEnv) return env;
+
+	if (hookEnv.runDir !== undefined) {
+		env["RALPH_RUN_DIR"] = hookEnv.runDir;
+	}
+	if (hookEnv.iteration !== undefined) {
+		env["RALPH_ITERATION"] = String(hookEnv.iteration);
+	}
+	if (hookEnv.scoutName !== undefined) {
+		env["RALPH_SCOUT_NAME"] = hookEnv.scoutName;
+	}
+	return env;
 }

--- a/src/core/loop-runner.ts
+++ b/src/core/loop-runner.ts
@@ -138,8 +138,14 @@ export async function runLoop(config: LoopConfig): Promise<LoopResult> {
 			// Log iteration start
 			log.step(pc.yellow(`Iteration ${iteration}`));
 
-			// Run kiro-cli
-			const exitCode = await client.runChat(config.prompt);
+			// Run kiro-cli. Pass hook env vars so .kiro/hooks/*.sh can write
+			// per-turn sidecar artifacts to the run directory without parsing
+			// the hook's stdin JSON payload (shape varies across Kiro versions).
+			const exitCode = await client.runChat(config.prompt, {
+				runDir: config.runDir ?? undefined,
+				iteration,
+				scoutName: config.scoutName ?? "",
+			});
 
 			if (exitCode !== 0) {
 				log.warn(pc.red(`Kiro exited with code ${exitCode}`));

--- a/src/core/loop-runner.ts
+++ b/src/core/loop-runner.ts
@@ -141,10 +141,15 @@ export async function runLoop(config: LoopConfig): Promise<LoopResult> {
 			// Run kiro-cli. Pass hook env vars so .kiro/hooks/*.sh can write
 			// per-turn sidecar artifacts to the run directory without parsing
 			// the hook's stdin JSON payload (shape varies across Kiro versions).
+			// When scoutCwd is set, spawn with that as cwd so Kiro picks up
+			// the per-scout `.kiro/` tree rather than the repo-root one.
 			const exitCode = await client.runChat(config.prompt, {
-				runDir: config.runDir ?? undefined,
-				iteration,
-				scoutName: config.scoutName ?? "",
+				hookEnv: {
+					runDir: config.runDir ?? undefined,
+					iteration,
+					scoutName: config.scoutName ?? "",
+				},
+				cwd: config.scoutCwd ?? undefined,
 			});
 
 			if (exitCode !== 0) {

--- a/src/core/scout-init.ts
+++ b/src/core/scout-init.ts
@@ -12,6 +12,8 @@
  */
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import probeTopicConfig from "../data/probe-topic.json";
+import probeTopicSteering from "../data/probe-topic.md" with { type: "text" };
 import agentConfig from "../data/project-watcher.json";
 import steeringContent from "../data/watcher-context.md" with { type: "text" };
 import { installHookScripts } from "./hook-installer";
@@ -35,15 +37,27 @@ export async function ensureScoutKiroTree(scoutDir: string): Promise<string> {
 		await mkdir(join(kiroDir, sub), { recursive: true });
 	}
 
-	// Agent config — idempotent write so bumps to the default propagate.
+	// Agent configs — idempotent writes so bumps to the defaults propagate.
+	// project-watcher is the scout's main agent; probe-topic is the
+	// intra-scout subagent it fans out to via use_subagent.
 	const agentPath = join(kiroDir, "agents", "project-watcher.json");
 	await Bun.write(agentPath, `${JSON.stringify(agentConfig, null, 2)}\n`);
 
-	// Steering — scout-local copy so each scout can diverge later without
-	// touching the repo-root file.
+	const probeAgentPath = join(kiroDir, "agents", "probe-topic.json");
+	await Bun.write(
+		probeAgentPath,
+		`${JSON.stringify(probeTopicConfig, null, 2)}\n`,
+	);
+
+	// Steering — scout-local copies so each scout can diverge later without
+	// touching the repo-root files. Preserved once a user has customized.
 	const steeringPath = join(kiroDir, "steering", "watcher-context.md");
 	if (!(await Bun.file(steeringPath).exists())) {
 		await Bun.write(steeringPath, steeringContent);
+	}
+	const probeSteeringPath = join(kiroDir, "steering", "probe-topic.md");
+	if (!(await Bun.file(probeSteeringPath).exists())) {
+		await Bun.write(probeSteeringPath, probeTopicSteering);
 	}
 
 	// Hooks — same scripts as repo-root, just re-stamped under the scout's

--- a/src/core/scout-init.ts
+++ b/src/core/scout-init.ts
@@ -11,12 +11,20 @@
  * @module core/scout-init
  */
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import probeTopicConfig from "../data/probe-topic.json";
 import probeTopicSteering from "../data/probe-topic.md" with { type: "text" };
 import agentConfig from "../data/project-watcher.json";
 import steeringContent from "../data/watcher-context.md" with { type: "text" };
 import { installHookScripts } from "./hook-installer";
+
+/**
+ * Derive the scout name from its directory so the knowledge-base index
+ * scopes to `results/<name>/**` and only sees this scout's own history.
+ */
+function scoutNameOf(scoutDir: string): string {
+	return basename(scoutDir);
+}
 
 /** Subfolders under a scout's `.kiro/`, stamped on first run. */
 const SCOUT_KIRO_SUBDIRS = ["agents", "steering", "hooks", "settings"] as const;
@@ -40,8 +48,34 @@ export async function ensureScoutKiroTree(scoutDir: string): Promise<string> {
 	// Agent configs — idempotent writes so bumps to the defaults propagate.
 	// project-watcher is the scout's main agent; probe-topic is the
 	// intra-scout subagent it fans out to via use_subagent.
+	//
+	// The default agentConfig ships with resources paths relative to the
+	// REPO-ROOT cwd (e.g. `../../watch-manifest.json`). When run from a
+	// scout cwd (`scouts/<name>/`), those paths are wrong — the manifest is
+	// right there as `manifest.json` and the loop state is
+	// `.kiro/ralph-loop.local.json`. We also attach a knowledge-base
+	// resource over past scout summaries so each scout sees only its own
+	// history — no cross-scout leakage. See src/data/probe-topic.md for
+	// the probe-topic contract.
+	const scoutAgent = {
+		...agentConfig,
+		resources: [
+			"file://manifest.json",
+			"file://.kiro/ralph-loop.local.json",
+			{
+				type: "knowledgeBase",
+				source: "file://../../results",
+				name: "scout-history",
+				description:
+					"Past summary.md files produced by this scout. Use to avoid re-discovering repos and to reference prior iteration findings.",
+				indexType: "best",
+				include: [`${scoutNameOf(scoutDir)}/**/summary.md`],
+				autoUpdate: true,
+			},
+		],
+	};
 	const agentPath = join(kiroDir, "agents", "project-watcher.json");
-	await Bun.write(agentPath, `${JSON.stringify(agentConfig, null, 2)}\n`);
+	await Bun.write(agentPath, `${JSON.stringify(scoutAgent, null, 2)}\n`);
 
 	const probeAgentPath = join(kiroDir, "agents", "probe-topic.json");
 	await Bun.write(

--- a/src/core/scout-init.ts
+++ b/src/core/scout-init.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Per-scout isolation bootstrap.
+ *
+ * Each scout owns its own `.kiro/` tree under `scouts/<name>/.kiro/` so
+ * scouts on divergent topics (ai-security, ai-eval, agent-sdks, ...) never
+ * share session history, steering, or agent config with their neighbors.
+ * Kiro discovers `.kiro/` relative to the subprocess cwd, so isolation is
+ * enforced at the OS process boundary — `runChat` is spawned with
+ * `cwd = scouts/<name>/` and reads that scout's `.kiro/` only.
+ *
+ * @module core/scout-init
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import agentConfig from "../data/project-watcher.json";
+import steeringContent from "../data/watcher-context.md" with { type: "text" };
+import { installHookScripts } from "./hook-installer";
+
+/** Subfolders under a scout's `.kiro/`, stamped on first run. */
+const SCOUT_KIRO_SUBDIRS = ["agents", "steering", "hooks", "settings"] as const;
+
+/**
+ * Ensure the per-scout `.kiro/` tree exists with a project-watcher agent,
+ * steering doc, and hook scripts. Idempotent. Called at the top of every
+ * scout run so new scouts produced by `ralph scout init` get bootstrapped
+ * on first use without an explicit migration step.
+ *
+ * @param scoutDir - Absolute path to `scouts/<name>/`.
+ * @returns Absolute path to the scout's `.kiro/` directory.
+ */
+export async function ensureScoutKiroTree(scoutDir: string): Promise<string> {
+	const kiroDir = join(scoutDir, ".kiro");
+
+	for (const sub of SCOUT_KIRO_SUBDIRS) {
+		await mkdir(join(kiroDir, sub), { recursive: true });
+	}
+
+	// Agent config — idempotent write so bumps to the default propagate.
+	const agentPath = join(kiroDir, "agents", "project-watcher.json");
+	await Bun.write(agentPath, `${JSON.stringify(agentConfig, null, 2)}\n`);
+
+	// Steering — scout-local copy so each scout can diverge later without
+	// touching the repo-root file.
+	const steeringPath = join(kiroDir, "steering", "watcher-context.md");
+	if (!(await Bun.file(steeringPath).exists())) {
+		await Bun.write(steeringPath, steeringContent);
+	}
+
+	// Hooks — same scripts as repo-root, just re-stamped under the scout's
+	// tree so Kiro finds them via cwd resolution.
+	await installHookScripts(join(kiroDir, "hooks"));
+
+	return kiroDir;
+}

--- a/src/core/watch-runner.ts
+++ b/src/core/watch-runner.ts
@@ -27,6 +27,10 @@ export interface WatchRunOptions {
 	maxIterations: number;
 	/** Optional agent name override */
 	agentName?: string | null;
+	/** Optional manifest file path override */
+	manifestPath?: string | null;
+	/** Optional scout name for results namespacing */
+	scoutName?: string | null;
 }
 
 /**
@@ -41,14 +45,17 @@ export function generateTaskId(): string {
 }
 
 /**
- * Reads and validates the watch manifest file.
+ * Reads and validates a watch manifest file.
  */
-export async function readManifest(): Promise<WatchManifest> {
-	const file = Bun.file(WATCH_MANIFEST_FILE);
+export async function readManifest(
+	manifestPath?: string | null,
+): Promise<WatchManifest> {
+	const path = manifestPath ?? WATCH_MANIFEST_FILE;
+	const file = Bun.file(path);
 
 	if (!(await file.exists())) {
 		throw new Error(
-			`Watch manifest not found at ${WATCH_MANIFEST_FILE}\nRun 'ralph watch init' first.`,
+			`Watch manifest not found at ${path}\nRun 'ralph watch init' first.`,
 		);
 	}
 
@@ -63,6 +70,7 @@ function buildWatchPrompt(
 	manifest: WatchManifest,
 	taskId: string,
 	resultsPath: string,
+	manifestPath: string,
 ): string {
 	const watchedRepos = manifest.watch
 		.map((w) => `  - ${w.repo} (${w.tags.join(", ")})`)
@@ -72,8 +80,10 @@ function buildWatchPrompt(
 
 TASK ID: ${taskId}
 RESULTS FOLDER: ${resultsPath}
+MANIFEST FILE: ${manifestPath}
 
 Write all output files to the results folder above. Create the iterations/ subdirectory as needed.
+Write manifest updates (auto-add, freshness tracking, discovery log) back to the MANIFEST FILE path above.
 
 WATCH MANIFEST:
 - Topics: ${manifest.topics.join(", ")}
@@ -105,11 +115,15 @@ async function writeStatus(
  */
 export async function runWatch(opts: WatchRunOptions): Promise<void> {
 	// Read manifest
-	const manifest = await readManifest();
+	const manifest = await readManifest(opts.manifestPath);
 
 	// Generate task ID and create results folder
+	// When running as a scout, namespace results under the scout name
 	const taskId = generateTaskId();
-	const resultsPath = join(RESULTS_DIR, taskId);
+	const resultsBase = opts.scoutName
+		? join(RESULTS_DIR, opts.scoutName)
+		: RESULTS_DIR;
+	const resultsPath = join(resultsBase, taskId);
 	const iterationsPath = join(resultsPath, "iterations");
 
 	await mkdir(iterationsPath, { recursive: true });
@@ -129,7 +143,13 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 	await writeStatus(resultsPath, status);
 
 	// Display startup info
-	log.info(pc.bold(pc.blue("Project Watcher starting")));
+	const label = opts.scoutName
+		? `Scout [${opts.scoutName}] starting`
+		: "Project Watcher starting";
+	log.info(pc.bold(pc.blue(label)));
+	if (opts.scoutName) {
+		log.message(`   Scout: ${pc.cyan(opts.scoutName)}`);
+	}
 	log.message(`   Task ID: ${pc.green(taskId)}`);
 	log.message(`   Topics: ${manifest.topics.join(", ")}`);
 	log.message(`   Languages: ${manifest.languages.join(", ")}`);
@@ -138,7 +158,13 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 	console.log();
 
 	// Build the prompt
-	const prompt = buildWatchPrompt(manifest, taskId, resultsPath);
+	const manifestFilePath = opts.manifestPath ?? WATCH_MANIFEST_FILE;
+	const prompt = buildWatchPrompt(
+		manifest,
+		taskId,
+		resultsPath,
+		manifestFilePath,
+	);
 
 	// Validate and run the loop
 	const config = LoopConfigSchema.parse({
@@ -175,8 +201,12 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 /**
  * Reads the status file for a given task ID.
  */
-export async function readStatus(taskId: string): Promise<WatchStatus | null> {
-	const statusPath = join(RESULTS_DIR, taskId, "status.json");
+export async function readStatus(
+	taskId: string,
+	scoutName?: string | null,
+): Promise<WatchStatus | null> {
+	const base = scoutName ? join(RESULTS_DIR, scoutName) : RESULTS_DIR;
+	const statusPath = join(base, taskId, "status.json");
 	const file = Bun.file(statusPath);
 
 	if (!(await file.exists())) {
@@ -190,8 +220,12 @@ export async function readStatus(taskId: string): Promise<WatchStatus | null> {
 /**
  * Reads the summary file for a given task ID.
  */
-export async function readSummary(taskId: string): Promise<string | null> {
-	const summaryPath = join(RESULTS_DIR, taskId, "summary.md");
+export async function readSummary(
+	taskId: string,
+	scoutName?: string | null,
+): Promise<string | null> {
+	const base = scoutName ? join(RESULTS_DIR, scoutName) : RESULTS_DIR;
+	const summaryPath = join(base, taskId, "summary.md");
 	const file = Bun.file(summaryPath);
 
 	if (!(await file.exists())) {
@@ -202,29 +236,41 @@ export async function readSummary(taskId: string): Promise<string | null> {
 }
 
 /**
- * Lists all watch runs in the results directory.
+ * A run entry with optional scout name.
  */
-export async function listRuns(): Promise<WatchStatus[]> {
-	// Check if results directory exists
+export interface WatchRunEntry extends WatchStatus {
+	scoutName?: string;
+}
+
+/**
+ * Lists watch runs, optionally filtered by scout name.
+ */
+export async function listRuns(
+	scoutName?: string | null,
+): Promise<WatchRunEntry[]> {
+	const base = scoutName ? join(RESULTS_DIR, scoutName) : RESULTS_DIR;
+
+	// Check if directory exists
 	try {
-		await readdir(RESULTS_DIR);
+		await readdir(base);
 	} catch {
 		return [];
 	}
 
-	const entries = await readdir(RESULTS_DIR);
-	const runs: WatchStatus[] = [];
+	const entries = await readdir(base);
+	const runs: WatchRunEntry[] = [];
 
 	for (const entry of entries) {
 		if (!entry.startsWith("pw-")) continue;
 
-		const statusPath = join(RESULTS_DIR, entry, "status.json");
+		const statusPath = join(base, entry, "status.json");
 		const statusFile = Bun.file(statusPath);
 
 		if (await statusFile.exists()) {
 			try {
 				const content = await statusFile.json();
-				runs.push(WatchStatusSchema.parse(content));
+				const status = WatchStatusSchema.parse(content);
+				runs.push({ ...status, scoutName: scoutName ?? undefined });
 			} catch {
 				// Skip invalid status files
 			}

--- a/src/core/watch-runner.ts
+++ b/src/core/watch-runner.ts
@@ -4,7 +4,7 @@
  * @module core/watch-runner
  */
 import { mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { log } from "@clack/prompts";
 import pc from "picocolors";
 import { LoopConfigSchema } from "../schemas/config";
@@ -12,10 +12,12 @@ import { type WatchManifest, WatchManifestSchema } from "../schemas/manifest";
 import { type WatchStatus, WatchStatusSchema } from "../schemas/results";
 import {
 	RESULTS_DIR,
+	SCOUTS_DIR,
 	WATCH_AGENT_NAME,
 	WATCH_MANIFEST_FILE,
 } from "../utils/paths";
 import { runLoop } from "./loop-runner";
+import { ensureScoutKiroTree } from "./scout-init";
 
 /**
  * Options for a watch run.
@@ -157,14 +159,33 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 	log.message(`   Iterations: ${opts.minIterations}-${opts.maxIterations}`);
 	console.log();
 
-	// Build the prompt
+	// Build the prompt. For scouts, use an absolute results path so the
+	// agent and hooks write to the correct location regardless of the
+	// subprocess cwd (scouts spawn kiro-cli with cwd=scouts/<name>/).
+	const absResultsPath = isAbsolute(resultsPath)
+		? resultsPath
+		: resolve(process.cwd(), resultsPath);
 	const manifestFilePath = opts.manifestPath ?? WATCH_MANIFEST_FILE;
+	const absManifestPath = isAbsolute(manifestFilePath)
+		? manifestFilePath
+		: resolve(process.cwd(), manifestFilePath);
 	const prompt = buildWatchPrompt(
 		manifest,
 		taskId,
-		resultsPath,
-		manifestFilePath,
+		absResultsPath,
+		absManifestPath,
 	);
+
+	// For scout runs, stamp the per-scout `.kiro/` tree and spawn kiro-cli
+	// with cwd=scouts/<name>/ so Kiro uses that scout's agents/steering/hooks
+	// instead of the repo-root ones. Non-scout watches keep running at the
+	// repo root for backwards compatibility.
+	let scoutCwd: string | null = null;
+	if (opts.scoutName) {
+		const scoutDir = resolve(process.cwd(), SCOUTS_DIR, opts.scoutName);
+		await ensureScoutKiroTree(scoutDir);
+		scoutCwd = scoutDir;
+	}
 
 	// Validate and run the loop
 	const config = LoopConfigSchema.parse({
@@ -173,8 +194,9 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 		maxIterations: opts.maxIterations,
 		completionPromise: "COMPLETE",
 		agentName: opts.agentName ?? WATCH_AGENT_NAME,
-		runDir: resultsPath,
+		runDir: absResultsPath,
 		scoutName: opts.scoutName ?? null,
+		scoutCwd,
 	});
 
 	try {

--- a/src/core/watch-runner.ts
+++ b/src/core/watch-runner.ts
@@ -173,6 +173,8 @@ export async function runWatch(opts: WatchRunOptions): Promise<void> {
 		maxIterations: opts.maxIterations,
 		completionPromise: "COMPLETE",
 		agentName: opts.agentName ?? WATCH_AGENT_NAME,
+		runDir: resultsPath,
+		scoutName: opts.scoutName ?? null,
 	});
 
 	try {

--- a/src/data/hooks/on-agent-spawn.sh
+++ b/src/data/hooks/on-agent-spawn.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Kiro `agentSpawn` hook — fired by kiro-cli when the agent starts a new turn.
+#
+# ralph-for-kiro sets these env vars on the subprocess before invoking kiro-cli
+# chat, so hooks always know where to write artifacts without parsing the
+# hook's JSON stdin payload:
+#
+#   RALPH_RUN_DIR       Absolute path to this run's `results/<scout>/pw-*/`
+#                       directory. Always exists.
+#   RALPH_ITERATION     1-based iteration number for this kiro-cli invocation.
+#   RALPH_SCOUT_NAME    Scout name (empty for non-scout watch runs).
+#
+# The hook writes an iteration-marker JSON so the runner never has to grep
+# stdout or re-read Kiro's SQLite DB to know a turn started.
+
+set -euo pipefail
+
+RUN_DIR="${RALPH_RUN_DIR:-}"
+ITERATION="${RALPH_ITERATION:-0}"
+
+if [[ -z "${RUN_DIR}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${RUN_DIR}/iterations"
+
+# Pad to 2 digits so `ls iterations/` sorts chronologically.
+ITER_PADDED="$(printf '%02d' "${ITERATION}")"
+MARKER="${RUN_DIR}/iterations/${ITER_PADDED}-spawn.json"
+
+cat > "${MARKER}" <<JSON
+{
+  "iteration": ${ITERATION},
+  "spawnedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "scout": "${RALPH_SCOUT_NAME:-}",
+  "cwd": "$(pwd)"
+}
+JSON

--- a/src/data/hooks/on-stop.sh
+++ b/src/data/hooks/on-stop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Kiro `stop` hook — fired when the agent signals the turn is complete.
+#
+# See on-agent-spawn.sh for the RALPH_* env-var contract. This hook writes a
+# per-turn `NN-turn.json` sidecar with a simple "turn ended" marker the loop
+# runner can watch for. Kiro versions vary in what they pipe on stdin for this
+# hook; we intentionally do not parse it — the env vars are enough.
+
+set -euo pipefail
+
+RUN_DIR="${RALPH_RUN_DIR:-}"
+ITERATION="${RALPH_ITERATION:-0}"
+
+if [[ -z "${RUN_DIR}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${RUN_DIR}/iterations"
+
+ITER_PADDED="$(printf '%02d' "${ITERATION}")"
+MARKER="${RUN_DIR}/iterations/${ITER_PADDED}-turn.json"
+
+cat > "${MARKER}" <<JSON
+{
+  "iteration": ${ITERATION},
+  "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "scout": "${RALPH_SCOUT_NAME:-}"
+}
+JSON

--- a/src/data/probe-topic.json
+++ b/src/data/probe-topic.json
@@ -1,0 +1,8 @@
+{
+	"name": "probe-topic",
+	"description": "Intra-scout subagent: deep-dives a single topic from the parent scout's manifest and returns a structured repo-discovery report. Invoked via use_subagent(InvokeSubagents) with one topic per call so topics are explored in parallel isolated contexts.",
+	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
+	"allowedTools": ["read", "@brave-search", "@tavily", "@exa"],
+	"includeMcpJson": true,
+	"prompt": "file://../steering/probe-topic.md"
+}

--- a/src/data/probe-topic.md
+++ b/src/data/probe-topic.md
@@ -1,0 +1,68 @@
+# Probe Topic Subagent
+
+You are a **single-topic deep-dive probe** for a Project Watcher scout.
+
+Your parent (the scout's `project-watcher` agent) spawned you with a single
+topic string and a results folder. You produce a structured Markdown report
+for that one topic and return. You never fan out further.
+
+## Inputs (from your query)
+
+- **Topic**: one of the parent scout's `manifest.topics` — e.g.
+  `ai-evaluation`, `llm-benchmarks`, `prompt-injection`.
+- **Languages**: languages worth filtering for (from parent manifest).
+- **Min stars / max age**: thresholds from the parent manifest.
+- **Results folder**: absolute path where you write your report.
+- **Watched repos**: already-tracked repos to skip or update freshness for.
+
+## What to do
+
+1. Search across `@brave-search`, `@tavily`, and `@exa` for trending GitHub
+   repositories matching the topic. Deduplicate by `owner/name`.
+2. For each candidate repo, note: star count, last-commit date, primary
+   language, and a one-sentence description.
+3. Filter to repos that:
+   - Meet or exceed the min-stars threshold
+   - Were updated within `maxAgeDays`
+   - Use one of the listed languages (or are language-agnostic tooling)
+4. Flag any candidate that exceeds the auto-add threshold — the parent will
+   roll these into the manifest.
+5. For already-watched repos you encounter, note their repo name in a
+   `freshness` section so the parent can bump `lastSeen`.
+
+## Output contract
+
+Write a single file to
+`<results-folder>/probes/<topic>.md` with exactly these sections:
+
+```markdown
+# Probe: <topic>
+
+## New candidates
+<repo>  <stars>⭐  <lang>  — <one-line description>
+  Source: <url>
+
+## Auto-add recommendations
+<repo>  <stars>⭐ — exceeds autoAddStars threshold of <N>
+
+## Freshness updates
+<repo>  — still active, seen today
+
+## Signals
+- <any structural observation about the topic landscape>
+
+## Queries used
+- <brave/tavily/exa query strings you ran>
+```
+
+Return the file path to the parent when done. Do **not** modify the manifest
+or write to any path outside your assigned results folder. The parent agent
+is responsible for rolling probe outputs into the scout summary and manifest.
+
+## Constraints
+
+- **One topic, one report.** Never search for other topics.
+- **Read-only toward the manifest.** You only write under
+  `<results-folder>/probes/`.
+- **No sibling coordination.** Don't try to read other probes' outputs —
+  your context is isolated by design.

--- a/src/data/project-watcher.json
+++ b/src/data/project-watcher.json
@@ -1,6 +1,6 @@
 {
 	"name": "project-watcher",
-	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages",
+	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages. Fans out per-topic deep dives to the probe-topic subagent.",
 	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
 	"allowedTools": ["*"],
 	"includeMcpJson": true,
@@ -9,6 +9,8 @@
 		"file://../ralph-loop.local.json"
 	],
 	"prompt": "file://../steering/watcher-context.md",
+	"availableAgents": ["probe-*"],
+	"trustedAgents": ["probe-topic"],
 	"hooks": {
 		"agentSpawn": [{ "command": ".kiro/hooks/on-agent-spawn.sh" }],
 		"stop": [{ "command": ".kiro/hooks/on-stop.sh" }]

--- a/src/data/project-watcher.json
+++ b/src/data/project-watcher.json
@@ -8,5 +8,9 @@
 		"file://../../watch-manifest.json",
 		"file://../ralph-loop.local.json"
 	],
-	"prompt": "file://../steering/watcher-context.md"
+	"prompt": "file://../steering/watcher-context.md",
+	"hooks": {
+		"agentSpawn": [{ "command": ".kiro/hooks/on-agent-spawn.sh" }],
+		"stop": [{ "command": ".kiro/hooks/on-stop.sh" }]
+	}
 }

--- a/src/data/ralph-wiggum.json
+++ b/src/data/ralph-wiggum.json
@@ -4,5 +4,9 @@
 	"tools": ["*"],
 	"allowedTools": ["*"],
 	"resources": ["file://../ralph-loop.local.json"],
-	"prompt": "file://../steering/ralph-context.md"
+	"prompt": "file://../steering/ralph-context.md",
+	"hooks": {
+		"agentSpawn": [{ "command": ".kiro/hooks/on-agent-spawn.sh" }],
+		"stop": [{ "command": ".kiro/hooks/on-stop.sh" }]
+	}
 }

--- a/src/data/watcher-context.md
+++ b/src/data/watcher-context.md
@@ -17,6 +17,22 @@ Read these files at the START of every iteration:
 - `.kiro/ralph-loop.local.json` - Loop state (iteration number, previous feedback)
 - The results folder path is provided in your prompt
 
+## Use `@path` References Inline (Kiro 1.26+)
+
+Prefer `@`-references over explicit read tool calls when you need to cite
+file contents. They pull the file into context directly — cheaper than
+`fs_read` and don't consume a tool-call turn:
+
+- `@manifest.json` — this scout's manifest (when running scout-scoped)
+- `@watch-manifest.json` — the repo-root manifest (non-scout watches)
+- `@.kiro/ralph-loop.local.json` — loop state for the current iteration
+
+The scout's own past findings are exposed via the `scout-history`
+knowledge-base resource (auto-indexed on agent spawn) — ask the agent
+about prior iterations through natural language; it will retrieve the
+relevant summaries automatically rather than requiring you to `@`-path
+specific files.
+
 ## Fan Out with the probe-topic Subagent
 
 When you have 2 or more topics in `manifest.topics`, delegate the per-topic

--- a/src/data/watcher-context.md
+++ b/src/data/watcher-context.md
@@ -17,6 +17,31 @@ Read these files at the START of every iteration:
 - `.kiro/ralph-loop.local.json` - Loop state (iteration number, previous feedback)
 - The results folder path is provided in your prompt
 
+## Fan Out with the probe-topic Subagent
+
+When you have 2 or more topics in `manifest.topics`, delegate the per-topic
+deep dives to the `probe-topic` subagent via `use_subagent` with
+`command: "InvokeSubagents"`. One subagent call per topic, all in parallel:
+
+```json
+{
+  "command": "InvokeSubagents",
+  "content": {
+    "subagents": [
+      { "agent_name": "probe-topic", "query": "topic=ai-evaluation, results=<RESULTS>, manifest=<MANIFEST_PATH>, min_stars=<N>, auto_add_stars=<M>, max_age_days=<D>, watched=[repo1, repo2, ...]" },
+      { "agent_name": "probe-topic", "query": "topic=llm-benchmarks, ..." }
+    ]
+  }
+}
+```
+
+Each probe writes one file to `<RESULTS>/probes/<topic>.md`. When all probes
+return, you read their outputs, roll auto-add recommendations into the
+manifest, bump `lastSeen` on freshness hits, and write the overall
+`summary.md`. Subagents run with isolated context — you own the synthesis.
+
+Skip the subagent hop if the scout has one topic only.
+
 ## Research Strategy by Phase
 
 ### Early Iterations (1-3): Broad Discovery

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import {
 	initCommand,
 	loopCommand,
 	resumeCommand,
+	scoutInitCommand,
+	scoutLsCommand,
+	scoutResultsCommand,
+	scoutRunCommand,
 	watchInitCommand,
 	watchLsCommand,
 	watchResultsCommand,
@@ -89,6 +93,8 @@ const watchCmd = program
 	)
 	.option("-m, --max-iterations <number>", "Maximum iterations", "10")
 	.option("-a, --agent <name>", "Agent name override")
+	.option("--manifest <path>", "Path to watch manifest file")
+	.option("--scout <name>", "Scout name (namespaces results)")
 	.action(watchRunCommand);
 
 watchCmd
@@ -107,5 +113,35 @@ watchCmd
 	.command("ls")
 	.description("List recent watch runs")
 	.action(watchLsCommand);
+
+// Scout command (fleet of focused watchers)
+const scoutCmd = program
+	.command("scout")
+	.description("Manage a fleet of focused discovery scouts")
+	.option("-n, --min-iterations <number>", "Minimum iterations per scout", "3")
+	.option("-m, --max-iterations <number>", "Maximum iterations per scout", "10")
+	.option("--name <name>", "Run a specific scout only")
+	.option("-a, --agent <name>", "Agent name override")
+	.action(scoutRunCommand);
+
+scoutCmd
+	.command("ls")
+	.description("List all available scouts")
+	.action(scoutLsCommand);
+
+scoutCmd
+	.command("results")
+	.description("Show results across scouts")
+	.argument("[name]", "Scout name (defaults to all)")
+	.action(scoutResultsCommand);
+
+scoutCmd
+	.command("init")
+	.description("Scaffold a new scout")
+	.argument("<name>", "Scout name (becomes directory name)")
+	.option("-t, --topics <topics>", "Comma-separated topics")
+	.option("-l, --languages <langs>", "Comma-separated languages")
+	.option("-f, --force", "Overwrite existing scout")
+	.action(scoutInitCommand);
 
 program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
 	scoutLsCommand,
 	scoutResultsCommand,
 	scoutRunCommand,
+	scoutStatusCommand,
+	scoutTailCommand,
 	watchInitCommand,
 	watchLsCommand,
 	watchResultsCommand,
@@ -122,6 +124,11 @@ const scoutCmd = program
 	.option("-m, --max-iterations <number>", "Maximum iterations per scout", "10")
 	.option("--name <name>", "Run a specific scout only")
 	.option("-a, --agent <name>", "Agent name override")
+	.option(
+		"-c, --concurrency <number>",
+		"Max scouts to run in parallel (default 1 = sequential)",
+		"1",
+	)
 	.action(scoutRunCommand);
 
 scoutCmd
@@ -143,5 +150,21 @@ scoutCmd
 	.option("-l, --languages <langs>", "Comma-separated languages")
 	.option("-f, --force", "Overwrite existing scout")
 	.action(scoutInitCommand);
+
+scoutCmd
+	.command("status")
+	.description("One-line-per-scout fleet summary of the latest run")
+	.action(scoutStatusCommand);
+
+scoutCmd
+	.command("tail")
+	.description("Follow a scout's in-flight run by watching iteration sidecars")
+	.argument("<name>", "Scout name to tail")
+	.option(
+		"-i, --interval <ms>",
+		"Poll interval in milliseconds (default 2000)",
+		"2000",
+	)
+	.action(scoutTailCommand);
 
 program.parse();

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -27,6 +27,14 @@ export const LoopConfigSchema = z.object({
 	isResume: z.boolean().default(false),
 	/** Iteration number to resume from. Default: 0 */
 	resumeFromIteration: z.number().int().min(0).default(0),
+	/**
+	 * Absolute path to the per-run results directory. When set, the runner
+	 * passes RALPH_RUN_DIR to kiro-cli so hook scripts can drop per-iteration
+	 * sidecar artifacts under `iterations/`.
+	 */
+	runDir: z.string().nullable().default(null),
+	/** Scout name for scout-scoped runs. Empty/null for non-scout watches. */
+	scoutName: z.string().nullable().default(null),
 });
 
 /**

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -35,6 +35,14 @@ export const LoopConfigSchema = z.object({
 	runDir: z.string().nullable().default(null),
 	/** Scout name for scout-scoped runs. Empty/null for non-scout watches. */
 	scoutName: z.string().nullable().default(null),
+	/**
+	 * Optional absolute working directory for the spawned kiro-cli process.
+	 * When set, the subprocess cwd is changed to this path. Used for scout
+	 * isolation: pointing at `scouts/<name>/` makes Kiro pick up the per-scout
+	 * `.kiro/` config tree (agents, steering, hooks, MCP config, session
+	 * history) instead of the shared root one.
+	 */
+	scoutCwd: z.string().nullable().default(null),
 });
 
 /**

--- a/src/types/text.d.ts
+++ b/src/types/text.d.ts
@@ -6,3 +6,8 @@ declare module "*.md" {
 	const content: string;
 	export default content;
 }
+
+declare module "*.sh" {
+	const content: string;
+	export default content;
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -44,3 +44,6 @@ export const WATCH_AGENT_NAME = "project-watcher";
 
 /** Directory for watch run results */
 export const RESULTS_DIR = "results";
+
+/** Directory for scout definitions */
+export const SCOUTS_DIR = "scouts";

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -36,6 +36,9 @@ export const AGENT_CONFIG_PATH = join(KIRO_AGENTS_DIR, "ralph-wiggum.json");
 /** Directory for kiro settings (MCP config, etc.) */
 export const KIRO_SETTINGS_DIR = join(KIRO_DIR, "settings");
 
+/** Directory for kiro lifecycle hook scripts */
+export const KIRO_HOOKS_DIR = join(KIRO_DIR, "hooks");
+
 /** Path to the watch manifest file */
 export const WATCH_MANIFEST_FILE = "watch-manifest.json";
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HOOK_FILES, installHookScripts } from "../src/core/hook-installer.ts";
@@ -49,13 +49,15 @@ describe("installHookScripts", () => {
 
 			for (const scriptName of Object.values(HOOK_FILES)) {
 				const scriptPath = join(hooksDir, scriptName);
-				// Single stat() — avoids the access()-then-stat TOCTOU that
-				// CodeQL flags as js/file-system-race. stat() throws ENOENT
-				// if the file doesn't exist, which fails the test cleanly.
-				const st = await stat(scriptPath);
+				// Bun.file gives us a single handle we derive both stat()
+				// (for mode check) and text() (for body check) from. CodeQL
+				// treats separate fs/promises.stat + readFile calls on the
+				// same path as a TOCTOU race (js/file-system-race).
+				const file = Bun.file(scriptPath);
+				const st = await file.stat();
 				expect(st.mode & 0o100).toBe(0o100);
 
-				const body = await readFile(scriptPath, "utf-8");
+				const body = await file.text();
 				expect(body.startsWith("#!/usr/bin/env bash")).toBe(true);
 				expect(body).toContain("RALPH_RUN_DIR");
 			}

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HOOK_FILES, installHookScripts } from "../src/core/hook-installer.ts";
+import { buildHookEnv } from "../src/core/kiro-client.ts";
+import { LoopConfigSchema } from "../src/schemas/config.ts";
+
+describe("buildHookEnv", () => {
+	test("returns parent env unchanged when no hook env is given", () => {
+		const env = buildHookEnv();
+		expect(env["PATH"]).toBe(process.env["PATH"]);
+		expect(env["RALPH_RUN_DIR"]).toBeUndefined();
+		expect(env["RALPH_ITERATION"]).toBeUndefined();
+	});
+
+	test("injects RALPH_* vars when hookEnv fields are provided", () => {
+		const env = buildHookEnv({
+			runDir: "/tmp/ralph-run",
+			iteration: 3,
+			scoutName: "ai-eval",
+		});
+		expect(env["RALPH_RUN_DIR"]).toBe("/tmp/ralph-run");
+		expect(env["RALPH_ITERATION"]).toBe("3");
+		expect(env["RALPH_SCOUT_NAME"]).toBe("ai-eval");
+	});
+
+	test("omits keys that are not provided", () => {
+		const env = buildHookEnv({ iteration: 1 });
+		expect(env["RALPH_ITERATION"]).toBe("1");
+		expect(env["RALPH_RUN_DIR"]).toBeUndefined();
+		expect(env["RALPH_SCOUT_NAME"]).toBeUndefined();
+	});
+
+	test("empty scoutName is still emitted (distinguishes scout vs non-scout)", () => {
+		const env = buildHookEnv({ scoutName: "" });
+		expect(env["RALPH_SCOUT_NAME"]).toBe("");
+	});
+});
+
+describe("installHookScripts", () => {
+	test("writes both hook scripts and makes them executable", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "ralph-hooks-"));
+		try {
+			const hooksDir = join(tempDir, "hooks");
+			const written = await installHookScripts(hooksDir);
+
+			expect(written.length).toBe(2);
+
+			for (const scriptName of Object.values(HOOK_FILES)) {
+				const scriptPath = join(hooksDir, scriptName);
+				await access(scriptPath);
+
+				const body = await readFile(scriptPath, "utf-8");
+				expect(body.startsWith("#!/usr/bin/env bash")).toBe(true);
+				expect(body).toContain("RALPH_RUN_DIR");
+
+				const st = await stat(scriptPath);
+				// Owner-executable bit set
+				expect(st.mode & 0o100).toBe(0o100);
+			}
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("is idempotent — second call overwrites cleanly", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "ralph-hooks-"));
+		try {
+			const hooksDir = join(tempDir, "hooks");
+			await installHookScripts(hooksDir);
+			const second = await installHookScripts(hooksDir);
+			expect(second.length).toBe(2);
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("LoopConfig runDir / scoutName defaults", () => {
+	test("runDir and scoutName default to null", () => {
+		const config = LoopConfigSchema.parse({
+			prompt: "test",
+			minIterations: 1,
+			maxIterations: 1,
+			completionPromise: "DONE",
+		});
+		expect(config.runDir).toBeNull();
+		expect(config.scoutName).toBeNull();
+	});
+
+	test("runDir and scoutName round-trip when set", () => {
+		const config = LoopConfigSchema.parse({
+			prompt: "test",
+			minIterations: 1,
+			maxIterations: 1,
+			completionPromise: "DONE",
+			runDir: "/tmp/pw-run",
+			scoutName: "ai-eval",
+		});
+		expect(config.runDir).toBe("/tmp/pw-run");
+		expect(config.scoutName).toBe("ai-eval");
+	});
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HOOK_FILES, installHookScripts } from "../src/core/hook-installer.ts";
@@ -49,15 +49,15 @@ describe("installHookScripts", () => {
 
 			for (const scriptName of Object.values(HOOK_FILES)) {
 				const scriptPath = join(hooksDir, scriptName);
-				await access(scriptPath);
+				// Single stat() — avoids the access()-then-stat TOCTOU that
+				// CodeQL flags as js/file-system-race. stat() throws ENOENT
+				// if the file doesn't exist, which fails the test cleanly.
+				const st = await stat(scriptPath);
+				expect(st.mode & 0o100).toBe(0o100);
 
 				const body = await readFile(scriptPath, "utf-8");
 				expect(body.startsWith("#!/usr/bin/env bash")).toBe(true);
 				expect(body).toContain("RALPH_RUN_DIR");
-
-				const st = await stat(scriptPath);
-				// Owner-executable bit set
-				expect(st.mode & 0o100).toBe(0o100);
 			}
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });

--- a/tests/scout-concurrency.test.ts
+++ b/tests/scout-concurrency.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Black-box test of the concurrency drain pattern used by
+ * runScoutsWithConcurrency (src/commands/scout.ts). We can't import that
+ * function directly — it's file-private — but the pattern is small enough
+ * to replicate and assert here so regressions in the ordering / error
+ * handling contract land as test failures rather than production surprises.
+ */
+async function drainWithConcurrency<T>(
+	items: T[],
+	concurrency: number,
+	task: (item: T) => Promise<boolean>,
+): Promise<Array<{ item: T; ok: boolean; error?: string }>> {
+	const queue = [...items];
+	const results: Array<{ item: T; ok: boolean; error?: string }> = [];
+	const workers: Promise<void>[] = [];
+	const n = Math.min(concurrency, items.length);
+
+	for (let i = 0; i < n; i++) {
+		workers.push(
+			(async () => {
+				while (queue.length > 0) {
+					const item = queue.shift();
+					if (item === undefined) break;
+					try {
+						const ok = await task(item);
+						results.push({ item, ok });
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : String(err);
+						results.push({ item, ok: false, error: msg });
+					}
+				}
+			})(),
+		);
+	}
+
+	await Promise.all(workers);
+
+	const ordered: Array<{ item: T; ok: boolean; error?: string }> = [];
+	for (const i of items) {
+		const r = results.find((x) => x.item === i);
+		if (r) ordered.push(r);
+	}
+	return ordered;
+}
+
+describe("concurrency drain pattern", () => {
+	test("runs all items with concurrency=1 (sequential)", async () => {
+		const items = ["a", "b", "c"];
+		const runAt: Array<[string, number]> = [];
+		const t0 = Date.now();
+		await drainWithConcurrency(items, 1, async (item) => {
+			runAt.push([item, Date.now() - t0]);
+			await new Promise((r) => setTimeout(r, 50));
+			return true;
+		});
+		// Each start time must be >= previous start time + ~50ms
+		for (let i = 1; i < runAt.length; i++) {
+			const prev = runAt[i - 1];
+			const cur = runAt[i];
+			if (!prev || !cur) continue;
+			expect(cur[1]).toBeGreaterThanOrEqual(prev[1] + 40);
+		}
+	});
+
+	test("parallelizes with concurrency=N for N workers", async () => {
+		const items = ["a", "b", "c", "d"];
+		const t0 = Date.now();
+		await drainWithConcurrency(items, 4, async () => {
+			await new Promise((r) => setTimeout(r, 50));
+			return true;
+		});
+		const elapsed = Date.now() - t0;
+		// All four should finish in ~50ms wall-clock, not 200ms.
+		expect(elapsed).toBeLessThan(150);
+	});
+
+	test("one failure does not abort the fleet", async () => {
+		const items = ["a", "b", "c"];
+		const out = await drainWithConcurrency(items, 2, async (item) => {
+			if (item === "b") throw new Error("boom");
+			return true;
+		});
+		expect(out.length).toBe(3);
+		expect(out.find((x) => x.item === "a")?.ok).toBe(true);
+		expect(out.find((x) => x.item === "b")?.ok).toBe(false);
+		expect(out.find((x) => x.item === "b")?.error).toBe("boom");
+		expect(out.find((x) => x.item === "c")?.ok).toBe(true);
+	});
+
+	test("results preserve input order regardless of finish order", async () => {
+		const items = ["a", "b", "c"];
+		const delays: Record<string, number> = { a: 90, b: 10, c: 50 };
+		const out = await drainWithConcurrency(items, 3, async (item) => {
+			await new Promise((r) => setTimeout(r, delays[item] ?? 0));
+			return true;
+		});
+		expect(out.map((x) => x.item)).toEqual(["a", "b", "c"]);
+	});
+});

--- a/tests/scout-init.test.ts
+++ b/tests/scout-init.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureScoutKiroTree } from "../src/core/scout-init.ts";
+
+describe("ensureScoutKiroTree", () => {
+	test("stamps a complete .kiro/ tree under a scout directory", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "ralph-scout-"));
+		try {
+			const scoutDir = join(tempDir, "my-scout");
+			const kiroDir = await ensureScoutKiroTree(scoutDir);
+
+			// Tree shape
+			for (const sub of ["agents", "steering", "hooks", "settings"]) {
+				await access(join(kiroDir, sub));
+			}
+
+			// Agent config present and parseable
+			const agentJson = await readFile(
+				join(kiroDir, "agents", "project-watcher.json"),
+				"utf-8",
+			);
+			const agent = JSON.parse(agentJson);
+			expect(agent.name).toBe("project-watcher");
+			expect(agent.hooks).toBeDefined();
+
+			// Steering file present
+			const steering = await readFile(
+				join(kiroDir, "steering", "watcher-context.md"),
+				"utf-8",
+			);
+			expect(steering.length).toBeGreaterThan(0);
+
+			// Hook scripts present and executable
+			for (const name of ["on-agent-spawn.sh", "on-stop.sh"]) {
+				const p = join(kiroDir, "hooks", name);
+				await access(p);
+				const st = await stat(p);
+				expect(st.mode & 0o100).toBe(0o100);
+			}
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("is idempotent — steering is preserved across repeat calls", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "ralph-scout-"));
+		try {
+			const scoutDir = join(tempDir, "my-scout");
+			const kiroDir = await ensureScoutKiroTree(scoutDir);
+
+			// Simulate user edit of the steering doc
+			const steeringPath = join(kiroDir, "steering", "watcher-context.md");
+			await Bun.write(steeringPath, "CUSTOMIZED\n");
+
+			// Re-run — should NOT overwrite steering
+			await ensureScoutKiroTree(scoutDir);
+			const after = await readFile(steeringPath, "utf-8");
+			expect(after).toBe("CUSTOMIZED\n");
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/scout-init.test.ts
+++ b/tests/scout-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureScoutKiroTree } from "../src/core/scout-init.ts";
@@ -11,9 +11,11 @@ describe("ensureScoutKiroTree", () => {
 			const scoutDir = join(tempDir, "my-scout");
 			const kiroDir = await ensureScoutKiroTree(scoutDir);
 
-			// Tree shape
+			// Tree shape — single stat() per subdir (throws if missing)
+			// avoids the access()-then-open TOCTOU CodeQL flags.
 			for (const sub of ["agents", "steering", "hooks", "settings"]) {
-				await access(join(kiroDir, sub));
+				const st = await stat(join(kiroDir, sub));
+				expect(st.isDirectory()).toBe(true);
 			}
 
 			// Agent config present and parseable
@@ -62,10 +64,9 @@ describe("ensureScoutKiroTree", () => {
 			);
 			expect(probeSteering.length).toBeGreaterThan(0);
 
-			// Hook scripts present and executable
+			// Hook scripts present and executable — single stat()
 			for (const name of ["on-agent-spawn.sh", "on-stop.sh"]) {
 				const p = join(kiroDir, "hooks", name);
-				await access(p);
 				const st = await stat(p);
 				expect(st.mode & 0o100).toBe(0o100);
 			}

--- a/tests/scout-init.test.ts
+++ b/tests/scout-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureScoutKiroTree } from "../src/core/scout-init.ts";
@@ -18,12 +18,11 @@ describe("ensureScoutKiroTree", () => {
 				expect(st.isDirectory()).toBe(true);
 			}
 
-			// Agent config present and parseable
-			const agentJson = await readFile(
+			// Agent config present and parseable (Bun.file reads without
+			// the stat+readFile TOCTOU pattern CodeQL flags).
+			const agent = await Bun.file(
 				join(kiroDir, "agents", "project-watcher.json"),
-				"utf-8",
-			);
-			const agent = JSON.parse(agentJson);
+			).json();
 			expect(agent.name).toBe("project-watcher");
 			expect(agent.hooks).toBeDefined();
 			// Subagent whitelist present so probe-topic can be spawned via
@@ -45,23 +44,19 @@ describe("ensureScoutKiroTree", () => {
 			expect(kb.include).toEqual(["my-scout/**/summary.md"]);
 
 			// probe-topic subagent present and parseable
-			const probeAgentJson = await readFile(
+			const probeAgent = await Bun.file(
 				join(kiroDir, "agents", "probe-topic.json"),
-				"utf-8",
-			);
-			const probeAgent = JSON.parse(probeAgentJson);
+			).json();
 			expect(probeAgent.name).toBe("probe-topic");
 
 			// Steering files present
-			const steering = await readFile(
+			const steering = await Bun.file(
 				join(kiroDir, "steering", "watcher-context.md"),
-				"utf-8",
-			);
+			).text();
 			expect(steering.length).toBeGreaterThan(0);
-			const probeSteering = await readFile(
+			const probeSteering = await Bun.file(
 				join(kiroDir, "steering", "probe-topic.md"),
-				"utf-8",
-			);
+			).text();
 			expect(probeSteering.length).toBeGreaterThan(0);
 
 			// Hook scripts present and executable — single stat()
@@ -87,7 +82,7 @@ describe("ensureScoutKiroTree", () => {
 
 			// Re-run — should NOT overwrite steering
 			await ensureScoutKiroTree(scoutDir);
-			const after = await readFile(steeringPath, "utf-8");
+			const after = await Bun.file(steeringPath).text();
 			expect(after).toBe("CUSTOMIZED\n");
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });

--- a/tests/scout-init.test.ts
+++ b/tests/scout-init.test.ts
@@ -24,13 +24,30 @@ describe("ensureScoutKiroTree", () => {
 			const agent = JSON.parse(agentJson);
 			expect(agent.name).toBe("project-watcher");
 			expect(agent.hooks).toBeDefined();
+			// Subagent whitelist present so probe-topic can be spawned via
+			// use_subagent but nothing else can.
+			expect(agent.availableAgents).toEqual(["probe-*"]);
+			expect(agent.trustedAgents).toEqual(["probe-topic"]);
 
-			// Steering file present
+			// probe-topic subagent present and parseable
+			const probeAgentJson = await readFile(
+				join(kiroDir, "agents", "probe-topic.json"),
+				"utf-8",
+			);
+			const probeAgent = JSON.parse(probeAgentJson);
+			expect(probeAgent.name).toBe("probe-topic");
+
+			// Steering files present
 			const steering = await readFile(
 				join(kiroDir, "steering", "watcher-context.md"),
 				"utf-8",
 			);
 			expect(steering.length).toBeGreaterThan(0);
+			const probeSteering = await readFile(
+				join(kiroDir, "steering", "probe-topic.md"),
+				"utf-8",
+			);
+			expect(probeSteering.length).toBeGreaterThan(0);
 
 			// Hook scripts present and executable
 			for (const name of ["on-agent-spawn.sh", "on-stop.sh"]) {

--- a/tests/scout-init.test.ts
+++ b/tests/scout-init.test.ts
@@ -29,6 +29,19 @@ describe("ensureScoutKiroTree", () => {
 			expect(agent.availableAgents).toEqual(["probe-*"]);
 			expect(agent.trustedAgents).toEqual(["probe-topic"]);
 
+			// Resources rewritten for scout cwd; includes the scoped
+			// knowledge-base index over this scout's own history.
+			expect(agent.resources).toContain("file://manifest.json");
+			const kb = agent.resources.find(
+				(r: unknown): r is { type: string; include: string[] } =>
+					typeof r === "object" && r !== null && "type" in r,
+			);
+			expect(kb).toBeDefined();
+			expect(kb.type).toBe("knowledgeBase");
+			// Scoped to THIS scout only — ai-security scout must not see
+			// ai-eval history and vice versa.
+			expect(kb.include).toEqual(["my-scout/**/summary.md"]);
+
 			// probe-topic subagent present and parseable
 			const probeAgentJson = await readFile(
 				join(kiroDir, "agents", "probe-topic.json"),


### PR DESCRIPTION
## Summary

Ships the scouts fleet end-to-end: *isolated* `kiro-cli` children per scout (no cross-topic confabulation), hook-driven per-turn artifacts, an intra-scout probe-topic subagent, scoped knowledge index, and fleet-level run/status/tail commands. Reshapes ralph-for-kiro from a repo-scoped watch loop into a fleet-of-sensors architecture.

## Milestones (6 commits)

| # | Commit | What |
|---|---|---|
| M0 | \`1380c9b\` | **feat: scouts** — first time the \`ralph scout\` command + 5 scout dirs + \`src/commands/scout.ts\` actually land on main (the code was running nightly from March but uncommitted). |
| M1 | \`806ee8a\` | **feat(hooks)** — wires Kiro 1.24 \`agentSpawn\` + \`stop\` hooks into both agents. \`.kiro/hooks/*.sh\` drop \`iterations/NN-{spawn,turn}.json\` sidecars via \`RALPH_*\` env (no reliance on stdin JSON shape). \`KiroClient\` gets hookEnv; \`LoopConfig\` gets \`runDir\` + \`scoutName\`. |
| M2a | \`8ead994\` | **feat(scouts): per-scout .kiro tree** — each scout gets its own \`.kiro/\` under \`scouts/<name>/.kiro/\`. \`kiro-cli\` spawns with \`cwd = scouts/<name>/\` so Kiro picks up that scout's agents/steering/hooks/session history. Process boundary = scout boundary. |
| M2b | \`041c7b9\` | **feat(scouts): probe-topic subagent** — new \`probe-topic\` intra-scout subagent invoked via \`use_subagent\` InvokeSubagents (one per manifest topic, in parallel). Parent \`project-watcher\` gets \`availableAgents:[\"probe-*\"]\`, \`trustedAgents:[\"probe-topic\"]\` glob whitelist (1.25 feature). |
| M3 | \`f30abbe\` | **feat(scouts): knowledge index + scout-cwd resources** — per-scout \`scout-history\` knowledge-base resource scoped to \`results/<this-scout>/**/summary.md\` only. Resources paths rewritten for scout cwd. Documents \`@path\` refs. |
| M4 | \`7194973\` | **feat(scouts): fleet ops** — \`ralph scout run --concurrency N\` (parallel workers, one failure never aborts the fleet), \`ralph scout status\` (one-line fleet summary), \`ralph scout tail <name>\` (stream hook sidecars of in-flight run). |

## Isolation model

Scouts on divergent topics (ai-security, ai-eval, agent-sdks, computer-use, inference-infra) can never cross-contaminate because:

1. **Process boundary.** Each scout = separate \`kiro-cli\` OS process.
2. **Filesystem boundary.** \`kiro-cli\` cwd = \`scouts/<name>/\`, and Kiro reads \`.kiro/\` relative to cwd — so each scout's agents, steering, hooks, and SQLite session history are physically separate.
3. **Subagent boundary.** \`use_subagent\` fan-out stays **inside** a single scout's homogeneous topic space (ai-eval's six topics are adjacent). A scout never spawns subagents that see any other scout's data.
4. **Knowledge-index boundary.** The \`scout-history\` KB resource's \`include\` glob is \`<this-scout>/**/summary.md\` — indexes disjoint by design.

## Test plan

Every milestone shipped with gates green:

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` (biome 2.4.12) — clean
- [x] \`bun test\` — **90/90 pass, 202 expects** (up from 76 on main)

New test coverage: hook env injection, hook-script installation (idempotency + executable bits), scout-init tree shape (agent config, probe-topic subagent, steering, hooks, KB index scoped to this scout), LoopConfig defaults for new fields, concurrency drain pattern (sequential / parallel / failure-tolerant / order-preserving).

## Decisions worth noting

- **Kiro CLI headless, ACP, crash-resume, cron-revival deferred.** Out of scope per user direction.
- **Global compaction settings not included.** Kiro docs confirm \`compaction.excludeContextWindowPercent\` lives in \`~/.kiro/settings/cli.json\`, which can't be isolated per scout. Users who want it run \`kiro-cli settings compaction.excludeContextWindowPercent 20\` once at their home level.
- **Biome \`useLiteralKeys\` disabled** — conflicts with TS strict \`noPropertyAccessFromIndexSignature\` on \`NodeJS.ProcessEnv\`. TS strict is the authority.