### PR TITLE
fix(scouts): add web_search/web_fetch fallback when MCPs auth-fail

### DIFF
--- a/src/data/probe-topic.json
+++ b/src/data/probe-topic.json
@@ -2,8 +2,23 @@
 	"name": "probe-topic",
 	"description": "Intra-scout subagent: deep-dives a single topic from the parent scout's manifest and returns a structured repo-discovery report. Invoked via use_subagent(InvokeSubagents) with one topic per call so topics are explored in parallel isolated contexts.",
 	"model": "claude-haiku-4-5-20251001",
-	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
-	"allowedTools": ["read", "@brave-search", "@tavily", "@exa"],
+	"tools": [
+		"read",
+		"write",
+		"web_search",
+		"web_fetch",
+		"@brave-search",
+		"@tavily",
+		"@exa"
+	],
+	"allowedTools": [
+		"read",
+		"web_search",
+		"web_fetch",
+		"@brave-search",
+		"@tavily",
+		"@exa"
+	],
 	"includeMcpJson": true,
 	"prompt": "file://../steering/probe-topic.md"
 }

--- a/src/data/probe-topic.md
+++ b/src/data/probe-topic.md
@@ -18,7 +18,10 @@ for that one topic and return. You never fan out further.
 ## What to do
 
 1. Search across `@brave-search`, `@tavily`, and `@exa` for trending GitHub
-   repositories matching the topic. Deduplicate by `owner/name`.
+   repositories matching the topic. Deduplicate by `owner/name`. If any of
+   those MCP providers returns an auth / rate-limit error, fall back to
+   Kiro's built-in `web_search` and `web_fetch` rather than abandoning the
+   topic.
 2. For each candidate repo, note: star count, last-commit date, primary
    language, and a one-sentence description.
 3. Filter to repos that:

--- a/src/data/project-watcher.json
+++ b/src/data/project-watcher.json
@@ -1,7 +1,15 @@
 {
 	"name": "project-watcher",
 	"description": "Iterative deep research agent for discovering trending GitHub repos matching watched topics and languages. Fans out per-topic deep dives to the probe-topic subagent.",
-	"tools": ["read", "write", "@brave-search", "@tavily", "@exa"],
+	"tools": [
+		"read",
+		"write",
+		"web_search",
+		"web_fetch",
+		"@brave-search",
+		"@tavily",
+		"@exa"
+	],
 	"allowedTools": ["*"],
 	"includeMcpJson": true,
 	"resources": [

--- a/src/data/watcher-context.md
+++ b/src/data/watcher-context.md
@@ -80,6 +80,15 @@ Cast a wide net across all search tools:
 - Search for blog posts announcing new tools and frameworks
 - Search for "awesome list" additions in your topic areas
 
+**Fallback — Kiro native `web_search` / `web_fetch`:**
+If a given MCP search provider returns an authentication or rate-limit
+error, fall back to the built-in `web_search` and `web_fetch` tools rather
+than giving up or synthesizing from training knowledge. Prefer the MCP
+providers for their structured results and source diversity, but do not
+treat them as the only path. A scout run with zero discoveries because all
+three MCPs auth-failed is a preventable failure mode — native search is
+always available.
+
 For each candidate repo found, record:
 - Full repo name (owner/repo)
 - GitHub URL


### PR DESCRIPTION
## Summary

- Add Kiro's native `web_search` and `web_fetch` to the tool whitelist for both scout agents (`project-watcher`, `probe-topic`), so they have an always-available fallback when Brave/Exa/Tavily MCP providers return auth or rate-limit errors.
- Update steering prompts to instruct the agents to prefer MCP providers for structured/source-diverse results but fall back to native tools on provider failure — rather than synthesizing from training knowledge or bootstrapping from prior runs.

## Motivation

On 2026-04-22 the full six-scout fleet (agent-sdks, ai-eval, ai-security, computer-use, hn-frontpage, inference-infra) completed with `status: complete`, `error: null`, and `reposAdded: 0` across the board. Root cause was that `BRAVE_API_KEY` / `EXA_API_KEY` / `TAVILY_API_KEY` were unavailable in the cron environment, so every MCP search server received an empty `${VAR}` and returned 401 / 422 / "Invalid API key".

Because the scout agents' tool whitelist contained only `["read","write","@brave-search","@tavily","@exa"]`, they had **no fallback tool to reach for**. Five scouts silently degraded to prior-run carry-forward or training knowledge; one (`inference-infra`) returned empty `discoveries: []`. None surfaced the failure — every scout reported completion with zero errors.

The env-var problem itself is fixed outside this repo (moved exports to `~/.zshenv` + `SHELL=/bin/zsh` in crontab). This PR fixes the fragility that let the failure go silent: giving the scouts access to native web tools means the next time any MCP provider flakes, they can still produce useful output.

## Changes

- `src/data/project-watcher.json`: add `web_search`, `web_fetch` to `tools`
- `src/data/probe-topic.json`: add `web_search`, `web_fetch` to both `tools` and `allowedTools`
- `src/data/watcher-context.md`: add "Fallback — Kiro native `web_search` / `web_fetch`" note in the Research Strategy section
- `src/data/probe-topic.md`: mention native fallback inline in the search step

Newly-initialized scouts will pick these up automatically via `ralph scout init --from-example`. Existing scout trees under `scouts/<name>/.kiro/agents/*.json` are user data (gitignored) and can be refreshed by re-running `init` or by patching in place.

## Test plan

- [x] `mise exec -- bun run typecheck` passes
- [x] `mise exec -- bun run lint` passes (biome auto-formatted the expanded arrays)
- [x] `mise exec -- bun test` — 101 tests pass, 0 fail
- [ ] Manual: re-run a scout with one of the MCP keys intentionally broken, verify it falls back to `web_search` and still produces a non-empty `discovery.json`